### PR TITLE
workflow에서의 jira issue 연결 방식 수정

### DIFF
--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -32,11 +32,6 @@ jobs:
           JIRA_KEY=$(echo "$HEAD_REF" | grep -oE 'MD-[0-9]+' || echo "")
            echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
 
-      # PR 본문을 JSON 형식으로 파싱하기 위한 jq 설치
-      - name: Install jq
-        if: steps.extract-jira-key.outputs.jira_key != '' # JIRA 이슈 키가 없는 경우에는 실행하지 않음
-        run: sudo apt-get update && sudo apt-get install -y jq
-
       - name: Add JIRA issue link to Comment
         if: steps.extract-jira-key.outputs.jira_key != '' # JIRA 이슈 키가 없는 경우에는 실행하지 않음
         uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Extract JIRA issue key from branch name
         id: extract-jira-key
         run: |
-          JIRA_KEY=$(echo ${{ github.head_ref }} | grep -oE 'MOD-[0-9]+' || echo "")
+          JIRA_KEY=$(echo ${{ github.head_ref }} | grep -oE 'MD-[0-9]+' || echo "")
           echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
 
       # PR 본문을 JSON 형식으로 파싱하기 위한 jq 설치
@@ -35,20 +35,11 @@ jobs:
         if: steps.extract-jira-key.outputs.jira_key != '' # JIRA 이슈 키가 없는 경우에는 실행하지 않음
         run: sudo apt-get update && sudo apt-get install -y jq
 
-      # https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#update-a-pull-request
-      - name: Add JIRA issue link to PR body
+      - name: Add JIRA issue link to Comment
         if: steps.extract-jira-key.outputs.jira_key != '' # JIRA 이슈 키가 없는 경우에는 실행하지 않음
-        run: |
-          PR_BODY=$(cat <<EOF
-          ${{ github.event.pull_request.body }}
-          EOF)
-          JIRA_KEY=${{ steps.extract-jira-key.outputs.jira_key }}
-          JIRA_LINK=$(printf "## 📝 관련 이슈\n\n[%s](%s/browse/%s)" "$JIRA_KEY" "${{ vars.JIRA_BASE_URL }}" "$JIRA_KEY")
-          UPDATED_BODY=$(printf "%s\n\n%s" "$JIRA_LINK" "$PR_BODY")
-          curl -L \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }} \
-            -d "$(jq -n --arg body "$UPDATED_BODY" '{body: $body}')"
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            ## 📝 관련 이슈
+
+            [${{ steps.extract-jira-key.outputs.jira_key }}](${{ vars.JIRA_BASE_URL }}/browse/${{ steps.extract-jira-key.outputs.jira_key }})

--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -26,6 +26,11 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 # 가장 최근 커밋만 가져오기
+
       - name: Extract JIRA issue key from branch name
         id: extract-jira-key
         env:

--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -23,6 +23,8 @@ jobs:
   add-jira-link:
     runs-on: ubuntu-latest
     if: github.event.action == 'opened' # PR 생성 시에만 실행
+    permissions:
+      pull-requests: write
     steps:
       - name: Extract JIRA issue key from branch name
         id: extract-jira-key

--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -32,7 +32,7 @@ jobs:
           HEAD_REF: ${{ github.head_ref }} # PR의 브랜치 이름
         run: |
           JIRA_KEY=$(echo "$HEAD_REF" | grep -oE 'MD-[0-9]+' || echo "")
-           echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
+          echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
 
       - name: Add JIRA issue link to Comment
         if: steps.extract-jira-key.outputs.jira_key != '' # JIRA 이슈 키가 없는 경우에는 실행하지 않음

--- a/.github/workflows/pr-review-manager.yml
+++ b/.github/workflows/pr-review-manager.yml
@@ -26,9 +26,11 @@ jobs:
     steps:
       - name: Extract JIRA issue key from branch name
         id: extract-jira-key
+        env:
+          HEAD_REF: ${{ github.head_ref }} # PR의 브랜치 이름
         run: |
-          JIRA_KEY=$(echo ${{ github.head_ref }} | grep -oE 'MD-[0-9]+' || echo "")
-          echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
+          JIRA_KEY=$(echo "$HEAD_REF" | grep -oE 'MD-[0-9]+' || echo "")
+           echo "jira_key=$JIRA_KEY" >> "$GITHUB_OUTPUT"
 
       # PR 본문을 JSON 형식으로 파싱하기 위한 jq 설치
       - name: Install jq


### PR DESCRIPTION
<!--PR 제목에 "@coderabbitai 제목" 이 들어있으면 CodeRabbit이 자동으로 제목을 생성해줍니다!-->

## 💻 작업 내용

- 새로 만들어진 워크스페이스에 맞게 jira key 변경했습니다.
- issue 링크를 본문에 추가하는 대신 comment로 추가하도록 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 내부 GitHub Actions 워크플로우 업데이트:
    * PR 작성자 자동 할당 작업 비활성화
    * PR에서 감지된 JIRA 키를 기반으로 PR 본문 대신 PR 코멘트에 간결한 JIRA 링크 게시
    * 리포지토리 체크아웃 단계 추가 및 처리 로직 간소화(추가 도구 설치·본문 업데이트 제거)
    * JIRA 키가 있을 때만 링크 게시되도록 조건화 및 키 패턴 변경 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->