### PR TITLE
정보 수정 페이지 구현

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,0 +1,9 @@
+import axiosInstance from '@/shared/api/axios';
+
+export const logout = () =>
+  axiosInstance.post('/user/logout', null, { useMock: true });
+
+export const unregister = () =>
+  axiosInstance.delete('/users/me', {
+    useMock: true,
+  });

--- a/src/features/auth/api/useLogout.ts
+++ b/src/features/auth/api/useLogout.ts
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ROUTE } from '@/shared/config/route';
+import { logout } from './authApi';
+
+export const useLogout = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      queryClient.clear();
+      navigate(ROUTE.login);
+    },
+  });
+};

--- a/src/features/auth/api/useLogout.ts
+++ b/src/features/auth/api/useLogout.ts
@@ -11,7 +11,7 @@ export const useLogout = () => {
     mutationFn: logout,
     onSuccess: () => {
       queryClient.clear();
-      navigate(ROUTE.login);
+      navigate(ROUTE.login, { replace: true });
     },
   });
 };

--- a/src/features/auth/api/useUnregister.ts
+++ b/src/features/auth/api/useUnregister.ts
@@ -11,7 +11,7 @@ export const useUnregister = () => {
     mutationFn: unregister,
     onSuccess: () => {
       queryClient.clear();
-      navigate(ROUTE.login);
+      navigate(ROUTE.login, { replace: true });
     },
   });
 };

--- a/src/features/auth/api/useUnregister.ts
+++ b/src/features/auth/api/useUnregister.ts
@@ -1,0 +1,17 @@
+import { useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { ROUTE } from '@/shared/config/route';
+import { unregister } from './authApi';
+
+export const useUnregister = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: unregister,
+    onSuccess: () => {
+      queryClient.clear();
+      navigate(ROUTE.login);
+    },
+  });
+};

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,2 @@
+export { default as LogoutButton } from './ui/LogoutButton';
+export { default as UnregisterButton } from './ui/UnregisterButton';

--- a/src/features/auth/ui/LogoutButton/index.styles.ts
+++ b/src/features/auth/ui/LogoutButton/index.styles.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+import { TextVariant } from '@/shared/ui/Text/index.styles';
+
+export const Button = styled.button`
+  padding: ${({ theme }) => `${theme.unit[12]} ${theme.unit[20]}`};
+  color: ${({ theme }) => theme.color.semantic.state.danger};
+  ${TextVariant('body1R')};
+`;

--- a/src/features/auth/ui/LogoutButton/index.tsx
+++ b/src/features/auth/ui/LogoutButton/index.tsx
@@ -1,0 +1,14 @@
+import { useLogout } from '../../api/useLogout';
+import * as S from './index.styles';
+
+function LogoutButton() {
+  const { mutate: logout, isPending } = useLogout();
+
+  return (
+    <S.Button onClick={() => logout()} disabled={isPending}>
+      {isPending ? '로그아웃 중...' : '로그아웃'}
+    </S.Button>
+  );
+}
+
+export default LogoutButton;

--- a/src/features/auth/ui/UnregisterButton/index.styles.ts
+++ b/src/features/auth/ui/UnregisterButton/index.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { TextVariant } from '@/shared/ui/Text/index.styles';
+
+export const Button = styled.button`
+  padding: ${({ theme }) => `${theme.unit[12]} ${theme.unit[20]}`};
+  ${TextVariant('body1R')};
+`;

--- a/src/features/auth/ui/UnregisterButton/index.tsx
+++ b/src/features/auth/ui/UnregisterButton/index.tsx
@@ -1,0 +1,14 @@
+import { useUnregister } from '../../api/useUnregister';
+import * as S from './index.styles';
+
+function UnregisterButton() {
+  const { mutate: unregister, isPending } = useUnregister();
+
+  return (
+    <S.Button onClick={() => unregister()} disabled={isPending}>
+      {isPending ? '탈퇴 중...' : '회원 탈퇴'}
+    </S.Button>
+  );
+}
+
+export default UnregisterButton;

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -35,6 +35,21 @@ const authHandlers = [
     };
     return HttpResponse.json(mockUserInfo);
   }),
+
+  http.post('/api/v1/user/logout', ({ request }) => {
+    const isMocked = request.headers.get('X-Mock-Request');
+    if (!isMocked || isMocked !== 'true') return passthrough();
+
+    return new HttpResponse(null, { status: 204 });
+  }),
+
+  // 회원 탈퇴 API
+  http.delete('/api/v1/users/me', ({ request }) => {
+    const isMocked = request.headers.get('X-Mock-Request');
+    if (!isMocked || isMocked !== 'true') return passthrough();
+
+    return new HttpResponse(null, { status: 204 });
+  }),
 ];
 
 export default authHandlers;

--- a/src/pages/my-edit/MyEditPage.tsx
+++ b/src/pages/my-edit/MyEditPage.tsx
@@ -1,5 +1,36 @@
+import { useNavigate } from 'react-router';
+import { ArrowLeft, Menu } from '@/shared/assets/svgs/icon';
+import Header from '@/shared/ui/Header';
+import Text from '@/shared/ui/Text';
+import Divider from '@/shared/ui/Divider';
+import { useTheme } from 'styled-components';
+import { LogoutButton, UnregisterButton } from '@/features/auth';
+// import { TermsLink } from './ui';
+
 function MyEditPage() {
-  return <div>정보 수정 페이지</div>;
+  const navigate = useNavigate();
+  const { unit } = useTheme();
+
+  return (
+    <>
+      <Header
+        type="TitleCenter"
+        leftButtonContent={
+          <>
+            <ArrowLeft width="1.5rem" />
+            <Text>뒤로가기</Text>
+          </>
+        }
+        leftButtonOnClick={() => navigate(-1)}
+        rightButtonContent={<Menu width="1.5rem" />}
+      />
+      {/* TODO: 이용 약관 페이지 추가 여부를 결정하고, 이용 약관 페이지를 생성한 다음 버튼 표시  */}
+      {/* <TermsLink /> */}
+      <Divider style={{ margin: `${unit[16]} 0` }} />
+      <UnregisterButton />
+      <LogoutButton />
+    </>
+  );
 }
 
 export default MyEditPage;

--- a/src/pages/my-edit/ui/TermsLink/index.styles.ts
+++ b/src/pages/my-edit/ui/TermsLink/index.styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+import { TextVariant } from '@/shared/ui/Text/index.styles';
+
+export const Link = styled.a`
+  padding: ${({ theme }) => `${theme.unit[12]} ${theme.unit[20]}`};
+  ${TextVariant('body1R')};
+`;

--- a/src/pages/my-edit/ui/TermsLink/index.tsx
+++ b/src/pages/my-edit/ui/TermsLink/index.tsx
@@ -2,7 +2,11 @@ import * as S from './index.styles';
 
 function TermsLink() {
   // TODO: 이용약관 페이지로 이동하도록 수정
-  return <S.Link href="">이용약관</S.Link>;
+  return (
+    <S.Link href="#" onClick={(e) => e.preventDefault()}>
+      이용약관
+    </S.Link>
+  );
 }
 
 export default TermsLink;

--- a/src/pages/my-edit/ui/TermsLink/index.tsx
+++ b/src/pages/my-edit/ui/TermsLink/index.tsx
@@ -1,0 +1,8 @@
+import * as S from './index.styles';
+
+function TermsLink() {
+  // TODO: 이용약관 페이지로 이동하도록 수정
+  return <S.Link href="">이용약관</S.Link>;
+}
+
+export default TermsLink;

--- a/src/pages/my-edit/ui/index.ts
+++ b/src/pages/my-edit/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as TermsLink } from './TermsLink';

--- a/src/shared/ui/Divider/index.tsx
+++ b/src/shared/ui/Divider/index.tsx
@@ -1,6 +1,7 @@
+import { HTMLAttributes } from 'react';
 import * as S from './index.style';
 
-interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
+interface DividerProps extends HTMLAttributes<HTMLDivElement> {
   height?: number;
 }
 

--- a/src/shared/ui/Divider/index.tsx
+++ b/src/shared/ui/Divider/index.tsx
@@ -1,15 +1,11 @@
 import * as S from './index.style';
 
-interface DividerProps {
+interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
   height?: number;
 }
 
-function Divider({ height = 8 }: DividerProps) {
-  return (
-    <div>
-      <S.Divider height={height} />
-    </div>
-  );
+function Divider({ height = 8, ...props }: DividerProps) {
+  return <S.Divider height={height} {...props} />;
 }
 
 export default Divider;


### PR DESCRIPTION
<!--PR 제목에 "@coderabbitai 제목" 이 들어있으면 CodeRabbit이 자동으로 제목을 생성해줍니다!-->

#23 에 이어서 작업해서 base branch를 그쪽에 맞춰두었습니다!
머지 전에 develop으로 바꿔둘게요!!

## 💻 작업 내용

정보 수정 페이지를 구현했습니다

- 이용 약관 페이지 이동 링크, 회원 탈퇴, 로그아웃 버튼 구현
- 회원 탈퇴, 로그아웃 api 함수, 훅, msw 핸들러 추가 (아직 api 명세가 없어 변경 가능성 있음)

이용 약관 페이지 버튼은 구현했는데, 저희가 아직 이용 약관 페이지 관련해서는 얘기를 해 본적이 없는 것 같아서 우선은 구현만 해두고 주석처리 해두었습니다!

## 📸 스크린샷

| 이용 약관 버튼 있음 | 이용 약관 버튼 없음 |
|---|---|
| <img width="1290" height="2796" alt="localhost_3000_my_edit(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/118be4d6-ad39-449c-92bd-ada65a646792" />  |  <img width="1290" height="2796" alt="localhost_3000_my_edit(iPhone 14 Pro Max) (1)" src="https://github.com/user-attachments/assets/073e3fe9-1b3a-4303-937d-00e2197faaa9" /> |

## 👻 리뷰 요구사항

개발하다보니 예전에 나름대로 정리했던 디렉토리 구조나 코드 구조가 여전히 좀 뒤죽박죽인 느낌이 들었습니다... (함수/변수 네이밍이나 api 함수 구조 등등...)
readme에 정리해뒀던 디렉토리 구조도 수정할 겸 다시 코드나 디렉토리 구조 일관성 부분을 확인해보면 좋겠다는 생각이 들어서,
남은 기능 개발하면서 좀 고민해보다가 나중에 여유 생기면 한번 살펴봐도 좋을 것 같습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그아웃 기능 추가
  * 회원 탈퇴 기능 추가

* **UI Improvements**
  * 내 정보 편집 페이지에 네비게이션 헤더 및 로그아웃·회원 탈퇴 버튼 추가
  * 이용약관 링크 컴포넌트 추가
  * 구분선(Divider)이 표준 HTML 속성(예: 이벤트, 속성 전달)을 지원하도록 개선

* **Chores**
  * 로그아웃·회원 탈퇴 동작에 대한 모의(API mock) 엔드포인트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->