### PR TITLE
개발 서버 CI/CD 워크플로우 설정

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,0 +1,43 @@
+# 개발서버 CI 워크플로우
+name: Dev CI
+
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Cache node modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          # 의존성이 변경될 때마다 새로운 캐시 생성
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
+          # 캐시 키가 정확히 일치하지 않을 경우, 일치하는 최신 캐시 검색
+          restore-keys: |
+            ${{ runner.OS }}-build-
+            ${{ runner.OS }}-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: yarn install
+
+      - name: Check Lint
+        run: yarn lint
+
+      - name: Run Unit Test
+        run: yarn test
+
+      - name: Build
+        env:
+          VITE_SERVER_URL: ${{ secrets.VITE_SERVER_URL }}
+          VITE_KAKAO_JAVASCRIPT_KEY: ${{ secrets.VITE_KAKAO_JAVASCRIPT_KEY }}
+          VITE_SUPABASE_PUBLIC_KEY: ${{ secrets.VITE_SUPABASE_PUBLIC_KEY }}
+        run: yarn build

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -20,6 +20,9 @@ jobs:
           node-version: 20
           cache: 'yarn'
 
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Install Dependencies
         # 락파일을 엄격하게 지키며 설치
         run: yarn install --frozen-lockfile

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -14,20 +14,18 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
-      - name: Cache node modules
-        uses: actions/cache@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: node_modules
-          # 의존성이 변경될 때마다 새로운 캐시 생성
-          key: ${{ runner.OS }}-build-${{ hashFiles('**/yarn.lock') }}
-          # 캐시 키가 정확히 일치하지 않을 경우, 일치하는 최신 캐시 검색
-          restore-keys: |
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
+          node-version: 20
+          cache: 'yarn'
 
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: yarn install
+        # 락파일을 엄격하게 지키며 설치
+        run: yarn install --frozen-lockfile
+
+      - name: Check Prettier
+        run: yarn prettier:check
 
       - name: Check Lint
         run: yarn lint

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install Dependencies
         # 락파일을 엄격하게 지키며 설치
+        env:
+          HUSKY: 0 # CI 환경에서는 git 훅이 불필요하므로 husky 비활성화
         run: yarn install --frozen-lockfile
 
       - name: Check Prettier

--- a/.github/workflows/prod-ci-cd.yml
+++ b/.github/workflows/prod-ci-cd.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
 
+      - name: Enable Corepack
+        run: corepack enable
+
       # Step 2: node_modules 캐싱
       - name: Cache node modules
         uses: actions/cache@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/shared/assets

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "prettier:check": "prettier --check src",
+    "prettier:fix": "prettier --write src",
     "preview": "vite preview",
     "svgr": "npx @svgr/cli -d src/shared/assets/svgs/icon --typescript --no-dimensions public/svgs",
     "pwa": "pwa-assets-generator --preset minimal public/pwa/moddo.svg",

--- a/package.json
+++ b/package.json
@@ -106,5 +106,6 @@
     "workerDirectory": [
       "public"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## 💻 작업 내용

간단한 개발 서버 CI/CD 워크플로우를 추가했습니다!

### CI

- 트리거 : develop 브랜치에 PR에 열리거나, 업데이트되는 경우
- 수행 작업 : pretteir, lint, test, build

### CD

Cloudflare page를 이용해서 배포했습니다!
직접 workflow를 구성하진 않고 그냥 대시보드에서 설정했어요!
develop 브랜치에 머지하면 개발 서버 배포되고, 다른 브랜치에 푸시되면 프리뷰 배포가 진행됩니다.
(팀원 추가가 가능한지 찾아보고, 가능하면 초대드릴게요!)

## 👻 리뷰 요구사항 (선택)

배포 url이 너무 못생기면 서브도메인 연결을 부탁드리려고 했는데, 제가 보기엔 그렇게 못생기지 않은 것 같기도 해서...? 그냥 둬도 괜찮을 것 같기도 합니다.. ㅎㅎ 의견 부탁드립니다!

👉 https://moddo-frontend.pages.dev 👈


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 개발 환경의 지속적 통합(CI) 워크플로우를 추가하여 코드 품질 검사 자동화
  * 프로덕션 CI/CD 파이프라인 개선 및 최적화
  * 코드 포맷팅 도구 설정 업데이트
  * 패키지 매니저 버전 명시로 개발 환경 안정성 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->