### PR TITLE
캐릭터 도감 / 모임원 조회 / 참여자 선택 실제 API 연결

### DIFF
--- a/src/entities/character/api/character.ts
+++ b/src/entities/character/api/character.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/shared/api/axios';
+import { parseDate } from '@/shared/lib/parseDate';
 import {
   CharacterItemData,
   CharacterItemsRawResponse,
@@ -8,6 +9,6 @@ export const getCharacterCollection = (): Promise<CharacterItemData[]> =>
   axiosInstance.get<CharacterItemsRawResponse>('/collections').then((res) =>
     res.data.collections.map((item) => ({
       ...item,
-      acquiredAt: item.acquiredAt ? new Date(item.acquiredAt) : null,
+      acquiredAt: parseDate(item.acquiredAt),
     }))
   );

--- a/src/entities/character/api/character.ts
+++ b/src/entities/character/api/character.ts
@@ -1,13 +1,13 @@
 import axiosInstance from '@/shared/api/axios';
 import {
+  CharacterItemData,
   CharacterItemsRawResponse,
-  CharacterItemsResponse,
 } from '../model/character.type';
 
-export const getCharacterCollection = (): Promise<CharacterItemsResponse> =>
-  axiosInstance.get<CharacterItemsRawResponse>('/collections').then((res) => ({
-    collections: res.data.collections.map((item) => ({
+export const getCharacterCollection = (): Promise<CharacterItemData[]> =>
+  axiosInstance.get<CharacterItemsRawResponse>('/collections').then((res) =>
+    res.data.collections.map((item) => ({
       ...item,
       acquiredAt: item.acquiredAt ? new Date(item.acquiredAt) : null,
-    })),
-  }));
+    }))
+  );

--- a/src/entities/character/api/character.ts
+++ b/src/entities/character/api/character.ts
@@ -1,9 +1,13 @@
 import axiosInstance from '@/shared/api/axios';
-import { CharacterItemsResponse } from '../model/character.type';
+import {
+  CharacterItemsRawResponse,
+  CharacterItemsResponse,
+} from '../model/character.type';
 
-export const getCharacterCollection = () =>
-  axiosInstance
-    .get<CharacterItemsResponse>('/character/collection', {
-      useMock: true,
-    })
-    .then((res) => res.data);
+export const getCharacterCollection = (): Promise<CharacterItemsResponse> =>
+  axiosInstance.get<CharacterItemsRawResponse>('/collections').then((res) => ({
+    collections: res.data.collections.map((item) => ({
+      ...item,
+      acquiredAt: item.acquiredAt ? new Date(item.acquiredAt) : null,
+    })),
+  }));

--- a/src/entities/character/config/character.ts
+++ b/src/entities/character/config/character.ts
@@ -1,65 +1,46 @@
-import { CharacterType } from '@/entities/character/model/character.type';
-
-export const CHARACTER_IMAGE_SIZE: Record<
-  CharacterType,
-  {
-    big: {
-      width?: string;
-      height?: string;
-    };
-    small: {
-      width?: string;
-      height?: string;
-    };
-  }
-> = {
+export const CHARACTER_DATA = {
   '천사 모또': {
-    big: {
-      width: '15rem',
+    imageSize: {
+      big: { width: '15rem' },
+      small: { width: '12rem' },
     },
-    small: {
-      width: '12rem',
-    },
+    description: '정산의 수호천사 등장!',
   },
   '러키 모또': {
-    big: {
-      width: '12.5rem',
+    imageSize: {
+      big: { width: '12.5rem' },
+      small: { width: '10rem' },
     },
-    small: {
-      width: '10rem',
-    },
+    description: '정산 성공! 좋은 일만 가득하길~',
   },
   '딸기 또또': {
-    big: {
-      width: '12.5rem',
+    imageSize: {
+      big: { width: '12.5rem' },
+      small: { width: '10rem', height: '10rem' },
     },
-    small: {
-      width: '10rem',
-      height: '10rem',
-    },
+    description: '정산 완료! 달콤한 하루 보내~',
   },
   '잠꾸러기 또또': {
-    big: {
-      width: '12.5rem',
+    imageSize: {
+      big: { width: '12.5rem' },
+      small: { width: '10rem' },
     },
-    small: {
-      width: '10rem',
-    },
+    description: '정산 끝났어? 이제 푹 잘 수 있겠네~',
   },
   '마법사 또또': {
-    big: {
-      height: '13.72844rem',
+    imageSize: {
+      big: { height: '13.72844rem' },
+      small: { height: '10.98275rem' },
     },
-    small: {
-      height: '10.98275rem',
-    },
+    description: '정산? 아브라카다브라! 해결 완료~',
   },
-};
-
-export const CHARACTER_DESCRIPTION: Record<CharacterType, string> = {
-  '천사 모또': '정산의 수호천사 등장!',
-  '러키 모또': '정산 성공! 좋은 일만 가득하길~',
-  '딸기 또또': '정산 완료! 달콤한 하루 보내~',
-  '잠꾸러기 또또': '정산 끝났어? 이제 푹 잘 수 있겠네~',
-  '마법사 또또': '정산? 아브라카다브라! 해결 완료~',
-};
+} satisfies Record<
+  string,
+  {
+    imageSize: {
+      big: { width?: string; height?: string };
+      small: { width?: string; height?: string };
+    };
+    description: string;
+  }
+>;

--- a/src/entities/character/model/character.type.ts
+++ b/src/entities/character/model/character.type.ts
@@ -14,10 +14,19 @@ export interface CharacterData {
 
 export interface CharacterItemData extends CharacterData {
   id: number;
-  isUnlocked: boolean;
-  unlockedAt: string | null;
+  acquiredAt: Date | null;
+}
+
+// API 원시 응답 타입 (JSON 파싱 직후, 변환 전)
+interface CharacterItemRaw extends CharacterData {
+  id: number;
+  acquiredAt: string | null;
 }
 
 export interface CharacterItemsResponse {
-  characters: CharacterItemData[];
+  collections: CharacterItemData[];
+}
+
+export interface CharacterItemsRawResponse {
+  collections: CharacterItemRaw[];
 }

--- a/src/entities/character/model/character.type.ts
+++ b/src/entities/character/model/character.type.ts
@@ -1,9 +1,7 @@
-export type CharacterType =
-  | '천사 모또'
-  | '러키 모또'
-  | '딸기 또또'
-  | '잠꾸러기 또또'
-  | '마법사 또또';
+import { CHARACTER_DATA } from '@/entities/character/config/character';
+
+// 새 캐릭터 추가 시 CHARACTER_DATA에만 추가하면 타입이 자동으로 확장됨
+export type CharacterType = keyof typeof CHARACTER_DATA;
 
 export interface CharacterData {
   name: CharacterType;

--- a/src/entities/character/model/character.type.ts
+++ b/src/entities/character/model/character.type.ts
@@ -21,10 +21,6 @@ interface CharacterItemRaw extends CharacterData {
   acquiredAt: string | null;
 }
 
-export interface CharacterItemsResponse {
-  collections: CharacterItemData[];
-}
-
 export interface CharacterItemsRawResponse {
   collections: CharacterItemRaw[];
 }

--- a/src/entities/member/api/assignMember.ts
+++ b/src/entities/member/api/assignMember.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/shared/api/axios';
+import { parseDate } from '@/shared/lib/parseDate';
 import { MemberProfile, MemberProfileRaw } from '../model/member.type';
 
 // 참여자 선택 api (로그인한 참여자가 정산에 참여하도록 프로필 설정)
@@ -12,6 +13,6 @@ export const assignMember = async (
   );
   return {
     ...response.data,
-    paidAt: response.data.paidAt ? new Date(response.data.paidAt) : null,
+    paidAt: parseDate(response.data.paidAt),
   };
 };

--- a/src/entities/member/api/assignMember.ts
+++ b/src/entities/member/api/assignMember.ts
@@ -1,15 +1,17 @@
 import axiosInstance from '@/shared/api/axios';
+import { MemberProfile, MemberProfileRaw } from '../model/member.type';
 
 // 참여자 선택 api (로그인한 참여자가 정산에 참여하도록 프로필 설정)
 export const assignMember = async (
   settlementCode: string,
   memberId: number
-): Promise<void> => {
-  await axiosInstance.post(
+): Promise<MemberProfile> => {
+  const response = await axiosInstance.post<MemberProfileRaw>(
     `/groups/${settlementCode}/members/assign`,
-    {
-      memberId,
-    },
-    { useMock: true }
+    { memberId }
   );
+  return {
+    ...response.data,
+    paidAt: response.data.paidAt ? new Date(response.data.paidAt) : null,
+  };
 };

--- a/src/entities/member/api/getProfiles.ts
+++ b/src/entities/member/api/getProfiles.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/shared/api/axios';
+import { parseDate } from '@/shared/lib/parseDate';
 import { MemberProfile, MemberProfileRawData } from '../model/member.type';
 
 // TODO : 기존 groupToken들을 사용하는 방식을 settlementCode를 사용하는 방식으로 변경해야 함.
@@ -11,6 +12,6 @@ export const getProfiles = async (
   );
   return response.data.members.map((member) => ({
     ...member,
-    paidAt: member.paidAt ? new Date(member.paidAt) : null,
+    paidAt: parseDate(member.paidAt),
   }));
 };

--- a/src/entities/member/api/getProfiles.ts
+++ b/src/entities/member/api/getProfiles.ts
@@ -1,14 +1,16 @@
 import axiosInstance from '@/shared/api/axios';
-import { MemberProfile, MemberProfileData } from '../model/member.type';
+import { MemberProfile, MemberProfileRawData } from '../model/member.type';
 
 // TODO : 기존 groupToken들을 사용하는 방식을 settlementCode를 사용하는 방식으로 변경해야 함.
 // 모임원 조회 API - 정산 참여자 프로필 조회
 export const getProfiles = async (
   settlementCode: string
 ): Promise<MemberProfile[]> => {
-  const response = await axiosInstance.get<MemberProfileData>(
-    `/groups/${settlementCode}/members`,
-    { useMock: true }
+  const response = await axiosInstance.get<MemberProfileRawData>(
+    `/groups/${settlementCode}/members`
   );
-  return response.data.members;
+  return response.data.members.map((member) => ({
+    ...member,
+    paidAt: member.paidAt ? new Date(member.paidAt) : null,
+  }));
 };

--- a/src/entities/member/model/member.type.ts
+++ b/src/entities/member/model/member.type.ts
@@ -27,6 +27,15 @@ export interface MemberProfile {
   paidAt: Date | null;
 }
 
+// API 원시 응답 타입 (JSON 파싱 직후, 변환 전)
+export interface MemberProfileRaw extends Omit<MemberProfile, 'paidAt'> {
+  paidAt: string | null;
+}
+
 export interface MemberProfileData {
   members: MemberProfile[];
+}
+
+export interface MemberProfileRawData {
+  members: MemberProfileRaw[];
 }

--- a/src/entities/member/model/member.type.ts
+++ b/src/entities/member/model/member.type.ts
@@ -32,10 +32,6 @@ export interface MemberProfileRaw extends Omit<MemberProfile, 'paidAt'> {
   paidAt: string | null;
 }
 
-export interface MemberProfileData {
-  members: MemberProfile[];
-}
-
 export interface MemberProfileRawData {
   members: MemberProfileRaw[];
 }

--- a/src/features/character-management/api/useGetCharacterCollection.ts
+++ b/src/features/character-management/api/useGetCharacterCollection.ts
@@ -7,9 +7,9 @@ const useGetCharacterCollection = () =>
     queryFn: getCharacterCollection,
     // 획득한 캐릭터가 가장 앞에 오도록 정렬
     select: (data) =>
-      [...data.characters].sort((a, b) => {
-        if (a.isUnlocked === b.isUnlocked) return 0;
-        return a.isUnlocked ? -1 : 1;
+      [...data.collections].sort((a, b) => {
+        if ((a.acquiredAt !== null) === (b.acquiredAt !== null)) return 0;
+        return a.acquiredAt !== null ? -1 : 1;
       }),
   });
 

--- a/src/features/character-management/api/useGetCharacterCollection.ts
+++ b/src/features/character-management/api/useGetCharacterCollection.ts
@@ -7,7 +7,7 @@ const useGetCharacterCollection = () =>
     queryFn: getCharacterCollection,
     // 획득한 캐릭터가 가장 앞에 오도록 정렬
     select: (data) =>
-      [...data.collections].sort((a, b) => {
+      [...data].sort((a, b) => {
         if ((a.acquiredAt !== null) === (b.acquiredAt !== null)) return 0;
         return a.acquiredAt !== null ? -1 : 1;
       }),

--- a/src/features/character-management/ui/CharacterBottomSheet/index.tsx
+++ b/src/features/character-management/ui/CharacterBottomSheet/index.tsx
@@ -3,7 +3,7 @@ import Text from '@/shared/ui/Text';
 import BottomSheet from '@/shared/ui/BottomSheet';
 import ButtonGroup from '@/shared/ui/ButtonGroup';
 import Button from '@/shared/ui/Button';
-import { CHARACTER_IMAGE_SIZE } from '@/entities/character/config/character';
+import { CHARACTER_DATA } from '@/entities/character/config/character';
 import { ROUTE } from '@/shared/config/route';
 import useGetCharacter from '@/features/character-management/api/useGetCharacter';
 import * as S from './index.styles';
@@ -33,7 +33,7 @@ function CharacterBottomSheet({ open, setOpen }: CharacterBottomSheetProps) {
             src={data.imageUrl}
             alt={data.name}
             style={{
-              ...CHARACTER_IMAGE_SIZE[data.name].small,
+              ...CHARACTER_DATA[data.name].imageSize.small,
             }}
           />
         </S.CharacterImageContainer>

--- a/src/features/character-management/ui/CharacterItem/index.tsx
+++ b/src/features/character-management/ui/CharacterItem/index.tsx
@@ -17,14 +17,14 @@ interface CharacterCardProps {
 }
 
 function CharacterCard({ character }: CharacterCardProps) {
-  const { imageUrl, name, unlockedAt } = character;
+  const { imageUrl, name, acquiredAt } = character;
 
   return (
     <S.CardContainer>
       <S.CharacterImage src={imageUrl} alt={name} />
       <Text variant="body2Sb">{name}</Text>
       <Text variant="caption">
-        {unlockedAt ? format(new Date(unlockedAt), 'yyyy.MM.dd') : null}
+        {acquiredAt ? format(acquiredAt, 'yyyy.MM.dd') : null}
       </Text>
     </S.CardContainer>
   );
@@ -35,7 +35,7 @@ interface CharacterItemProps {
 }
 
 function CharacterItem({ character }: CharacterItemProps) {
-  if (!character.isUnlocked) return <LockedCharacterCard />;
+  if (!character.acquiredAt) return <LockedCharacterCard />;
   return <CharacterCard character={character} />;
 }
 

--- a/src/features/join/api/useAssignMember.ts
+++ b/src/features/join/api/useAssignMember.ts
@@ -1,13 +1,30 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { assignMember } from '@/entities/member/api/assignMember';
+import { MemberProfile } from '@/entities/member/model/member.type';
+import useMutationWithHandlers from '@/shared/hooks/useMutationWithHanders';
+import { showToast } from '@/shared/ui/Toast';
 
 const useAssignMember = (groupToken: string) => {
   const queryClient = useQueryClient();
-  return useMutation({
+
+  return useMutationWithHandlers<MemberProfile, Error, number>({
     mutationFn: (memberId: number) => assignMember(groupToken, memberId),
-    onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ['profiles', groupToken] });
+    onSuccess: (data) => {
+      // 응답으로 받은 업데이트된 멤버 정보로 캐시를 직접 갱신 (리패치 없이 즉시 반영)
+      queryClient.setQueryData<MemberProfile[]>(
+        ['profiles', groupToken],
+        (prev) => prev?.map((member) => (member.id === data.id ? data : member))
+      );
     },
+    // TODO: 에러 코드 확인 후 케이스별 메시지로 세분화 필요
+    errorHandlers: {
+      default: () =>
+        showToast({
+          type: 'error',
+          content: '참여자 선택에 실패했어요. 다시 시도해 주세요.',
+        }),
+    },
+    ignoreBoundaryErrors: [400, 409],
   });
 };
 

--- a/src/mocks/handlers/character.ts
+++ b/src/mocks/handlers/character.ts
@@ -1,45 +1,42 @@
 import { http, HttpResponse, passthrough } from 'msw';
-import { CharacterItemsResponse } from '@/entities/character/model/character.type';
+import { CharacterItemsRawResponse } from '@/entities/character/model/character.type';
 import getIsMocked from '@/mocks/lib/getIsMocked';
 
 const characterHandlers = [
-  http.get('/api/v1/character/collection', async ({ request }) => {
+  http.get('/api/v1/collections', async ({ request }) => {
     if (!getIsMocked(request)) return passthrough();
 
-    const dummyCharacterCollectionResponse: CharacterItemsResponse = {
-      characters: [
+    const dummyCharacterCollectionResponse: CharacterItemsRawResponse = {
+      collections: [
         {
           id: 1,
           name: '마법사 또또',
-          isUnlocked: true,
           imageUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/wizard_ddoddo.png',
           imageBigUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/wizard_ddoddo.png',
           rarity: 3,
-          unlockedAt: '2025-02-03T00:00:00Z',
+          acquiredAt: '2025-02-03T00:00:00Z',
         },
         {
           id: 2,
           name: '천사 모또',
-          isUnlocked: true,
           imageUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/angel_moddo.png',
           imageBigUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/angel_moddo.png',
           rarity: 2,
-          unlockedAt: '2025-02-03T00:00:00Z',
+          acquiredAt: '2025-02-03T00:00:00Z',
         },
         {
           id: 3,
           name: '딸기 또또',
-          isUnlocked: false,
           imageUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/strawberry_ddoddo.png',
           imageBigUrl:
             'https://ylsrfiwjufyciwoidcaz.supabase.co/storage/v1/object/public/moddo/strawberry_ddoddo.png',
           rarity: 1,
-          unlockedAt: null,
+          acquiredAt: null,
         },
       ],
     };

--- a/src/pages/characterShare/CharacterSharePage.tsx
+++ b/src/pages/characterShare/CharacterSharePage.tsx
@@ -9,10 +9,7 @@ import { ArrowLeft, Download } from '@/shared/assets/svgs/icon';
 import Header from '@/shared/ui/Header';
 import Text from '@/shared/ui/Text';
 import { BottomButtonContainer } from '@/shared/styles/bottomButton.styles';
-import {
-  CHARACTER_DESCRIPTION,
-  CHARACTER_IMAGE_SIZE,
-} from '@/entities/character/config/character';
+import { CHARACTER_DATA } from '@/entities/character/config/character';
 import StarChip from '@/features/character-management/ui/StarChip';
 import useGetCharacter from '@/features/character-management/api/useGetCharacter';
 import * as S from './CharacterSharePage.styles';
@@ -101,7 +98,7 @@ function CharacterSharePage() {
                 src={data.imageBigUrl}
                 alt={data.name}
                 style={{
-                  ...CHARACTER_IMAGE_SIZE[data.name].big,
+                  ...CHARACTER_DATA[data.name].imageSize.big,
                 }}
               />
             </S.CharacterImageContainer>
@@ -109,7 +106,7 @@ function CharacterSharePage() {
               {data.name}
             </Text>
             <Text variant="body1R" color="semantic.text.subtle">
-              {CHARACTER_DESCRIPTION[data.name]}
+              {CHARACTER_DATA[data.name].description}
             </Text>
           </S.CharacterCard>
         </S.CharacterCardContainer>

--- a/src/shared/lib/parseDate.ts
+++ b/src/shared/lib/parseDate.ts
@@ -1,0 +1,13 @@
+import { isValid, parseISO } from 'date-fns';
+
+/**
+ * API 응답의 ISO 날짜 문자열을 Date 객체로 변환합니다.
+ *
+ * new Date("invalid")는 truthy한 Invalid Date를 반환해 이후 format() 등에서 RangeError를 반환하기 때문에 parseISO + isValid로 유효성을 검사한 후 변환합니다.
+ * 유효하지 않으면 null을 반환합니다.
+ */
+export const parseDate = (value: string | null): Date | null => {
+  if (!value) return null;
+  const parsed = parseISO(value);
+  return isValid(parsed) ? parsed : null;
+};


### PR DESCRIPTION
## 💻 작업 내용

### 실제 API 연결 (mock 제거)

**캐릭터 도감 조회 (`GET /collections`)**
- 엔드포인트 변경: `/character/collection` → `/collections`
- 응답 구조 변경: `characters` → `collections`, 
`isUnlocked` 제거 → `acquiredAt: Date | null`로 잠금 여부 판단
- API 함수에서  `acquiredAt` string → Date 변환 (Raw 타입 / 변환 타입 분리)

**모임원 조회 (`GET /groups/{code}/members`)**
- `paidAt` string → Date 변환을 API 함수에서 처리
- `MemberProfileRaw` / `MemberProfileRawData` Raw 타입 추가

**참여자 선택 (`POST /groups/{code}/members/assign`)**
- 반환 타입 `void` → `MemberProfile` (응답으로 받은 멤버 객체 활용)
- `removeQueries` → `setQueryData` 교체: 응답 데이터로 캐시를 즉시 갱신해 리패치 없이 반영
- 에러 처리: `useMutation` → `useMutationWithHandlers`, 실패 시 toast 표시

### 코드 개선

**캐릭터 데이터 통합 (`CHARACTER_DATA`)**
- 기존: `CharacterType` union + `CHARACTER_IMAGE_SIZE` + `CHARACTER_DESCRIPTION` 세 곳을 각각 관리
- 변경: 단일 `CHARACTER_DATA` 객체로 통합, `CharacterType`을 `keyof typeof CHARACTER_DATA`로 파생
- 새 캐릭터 추가 시 `CHARACTER_DATA` 한 곳만 수정하면 타입이 자동으로 확장됨

**`getCharacterCollection` wrapper 제거**
- 변환 후에도 `{ collections: [...] }` wrapper를 유지하다 `select`에서 즉시 꺼내는 불필요한 구조 제거
- API 함수가 `CharacterItemData[]`를 직접 반환하도록 변경, `CharacterItemsResponse` 타입 제거

그 외에 사용하지 않는 타입을 제거했습니다!

## 👻 리뷰 요구사항

**참여자 선택 에러 처리**

실제 에러 코드가 API 문서에 명시되지 않아 `ignoreBoundaryErrors: [400, 409]`로 임시 처리하고 TODO를 남겼습니다. 실제 에러 코드 확인 후에 세부적으로 처리하겠습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캐릭터 획득 날짜 추적 및 표시 기능 강화

* **버그 수정**
  * 회원 프로필 할당 시 캐시 동기화 개선
  * 오류 처리 로직 강화

* **리팩터**
  * 캐릭터 정보 데이터 구조 통합
  * 날짜 파싱 및 변환 정규화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->