### PR TITLE
API 엔드포인트 일괄 변경 및 모임 생성 플로우 정리

### DIFF
--- a/src/entities/character/api/image.ts
+++ b/src/entities/character/api/image.ts
@@ -5,7 +5,7 @@ const image = {
   // GET GetCharacter
   getCharacter: (groupToken: string): Promise<CharacterData> =>
     axiosInstance
-      .get(`/groups/${groupToken}/character`)
+      .get('/character', { params: { code: groupToken } })
       .then((res) => res.data),
 };
 

--- a/src/entities/expense/api/expense.ts
+++ b/src/entities/expense/api/expense.ts
@@ -3,7 +3,6 @@ import {
   SingleExpenseForm,
   ExpenseList,
   ExpenseDetailList,
-  ExpenseLinkList,
 } from '@/entities/expense/model/expense.type';
 import axiosInstance from '@/shared/api/axios';
 
@@ -44,13 +43,6 @@ const expense = {
   getDetail: (groupToken: string): Promise<ExpenseDetailList> =>
     axiosInstance
       .get(`/groups/${groupToken}/expenses/details`)
-      .then((res) => res.data),
-
-  // GET links (링크 관리 페이지에서 조회되는 데이터)
-  // NOTE : API 명세서에 없는 데이터이므로 요청 url 변경 가능성 있음
-  getLinks: (): Promise<ExpenseLinkList> =>
-    axiosInstance
-      .get(`/expenses/links`, { useMock: true })
       .then((res) => res.data),
 };
 

--- a/src/entities/group/api/group.ts
+++ b/src/entities/group/api/group.ts
@@ -4,6 +4,7 @@ import {
   CreateGroupData,
   Group,
   GroupHeaderResponse,
+  GroupListItem,
   SettlementGroup,
   SettlementSort,
   SettlementStatus,
@@ -53,4 +54,8 @@ export const getSettlementList = (
   return axiosInstance
     .get('/groups', { params: { status, sort, limit } })
     .then((res) => res.data);
+};
+
+export const getGroupList = (): Promise<GroupListItem[]> => {
+  return axiosInstance.get('/groups/list').then((res) => res.data);
 };

--- a/src/entities/group/api/groupMembers.ts
+++ b/src/entities/group/api/groupMembers.ts
@@ -1,21 +1,21 @@
 import axiosInstance from '@/shared/api/axios';
-import { Member, MemberData } from '@/entities/member/model/member.type';
+import { Member } from '@/entities/member/model/member.type';
 
 export interface CreateGroupMembersVariable {
   name: string;
 }
 
 const groupMembers = {
-  // PUT addGroupMember
-  put: async ({
+  // POST addGroupMember
+  post: async ({
     groupMemberData,
     groupToken,
   }: {
-    groupMemberData: MemberData;
+    groupMemberData: CreateGroupMembersVariable;
     groupToken: string;
   }) => {
-    const response = await axiosInstance.put<Member>(
-      `/group-members?groupToken=${groupToken}`,
+    const response = await axiosInstance.post<Member>(
+      `/groups/${groupToken}/members`,
       groupMemberData
     );
     return response.data;
@@ -29,7 +29,7 @@ const groupMembers = {
     groupMemberId: number;
   }) => {
     const response = await axiosInstance.delete(
-      `/group-members/${groupMemberId}?groupToken=${groupToken}`
+      `/groups/${groupToken}/members/${groupMemberId}`
     );
     return response.data;
   },

--- a/src/entities/group/api/groupMembers.ts
+++ b/src/entities/group/api/groupMembers.ts
@@ -1,8 +1,9 @@
 import axiosInstance from '@/shared/api/axios';
-import { Member } from '@/entities/member/model/member.type';
+import { Member, MemberRole } from '@/entities/member/model/member.type';
 
 export interface CreateGroupMembersVariable {
   name: string;
+  role: MemberRole;
 }
 
 const groupMembers = {

--- a/src/entities/group/model/group.type.ts
+++ b/src/entities/group/model/group.type.ts
@@ -28,6 +28,15 @@ export interface GroupHeaderResponse {
   accountNumber: string;
 }
 
+export interface GroupListItem {
+  settlementId: number;
+  name: string;
+  groupCode: string;
+  createdAt: string;
+  completedAt: string | null;
+  members: Member[];
+}
+
 export type SettlementStatus = 'ALL' | 'IN_PROGRESS' | 'COMPLETED';
 export type SettlementSort = 'LATEST' | 'OLDEST';
 

--- a/src/entities/settlement/api/updatePaymentStatus.ts
+++ b/src/entities/settlement/api/updatePaymentStatus.ts
@@ -10,7 +10,7 @@ export const updatePaymentStatus = async ({
   isPaid,
 }: UpdatePaymentStatusVariable): Promise<UpdatePaymentStatusData> => {
   const response = await axiosInstance.put(
-    `/groups/${groupToken}/members/${groupMemberId}/payment`,
+    `/groups/${groupToken}/members/${groupMemberId}`,
     { isPaid }
   );
   return response.data;

--- a/src/features/character-management/api/useGetCharacter.ts
+++ b/src/features/character-management/api/useGetCharacter.ts
@@ -5,8 +5,6 @@ const useGetCharacter = (groupToken: string) => {
   return useQuery({
     queryKey: ['randomCharacter', groupToken],
     queryFn: () => image.getCharacter(groupToken),
-    throwOnError: false,
-    retry: false,
   });
 };
 

--- a/src/features/character-management/api/useGetCharacter.ts
+++ b/src/features/character-management/api/useGetCharacter.ts
@@ -5,6 +5,8 @@ const useGetCharacter = (groupToken: string) => {
   return useQuery({
     queryKey: ['randomCharacter', groupToken],
     queryFn: () => image.getCharacter(groupToken),
+    throwOnError: false,
+    retry: false,
   });
 };
 

--- a/src/features/expense-management/api/useGetExpensesLinks.ts
+++ b/src/features/expense-management/api/useGetExpensesLinks.ts
@@ -1,14 +1,14 @@
-import expense from '@/entities/expense/api/expense';
+import { getGroupList } from '@/entities/group/api/group';
 import useQueryWithHandlers from '@/shared/hooks/useQueryWithHandlers';
 import { ErrorHandlers, IgnoreBoundaryErrors } from '@/shared/types/error.type';
 
-const useGetExpensesLinks = (
+const useGetGroupLinks = (
   errorHandlers: ErrorHandlers,
   ignoreBoundaryErrors: IgnoreBoundaryErrors
 ) => {
   const query = useQueryWithHandlers({
-    queryKey: ['expense-links'],
-    queryFn: expense.getLinks,
+    queryKey: ['group-list'],
+    queryFn: getGroupList,
     staleTime: 10 * 60 * 1000, // 10분
     gcTime: 60 * 60 * 1000, // 1시간
     errorHandlers,
@@ -18,4 +18,4 @@ const useGetExpensesLinks = (
   return query;
 };
 
-export default useGetExpensesLinks;
+export default useGetGroupLinks;

--- a/src/pages/createExpenseStep/CreateExpenseStepPage.tsx
+++ b/src/pages/createExpenseStep/CreateExpenseStepPage.tsx
@@ -114,7 +114,7 @@ function CreateExpenseStepPage({ onNext }: CreateExpenseStepProps) {
           )}
           disabled={!allFormsValid}
         >
-          {`총 ${getTotalExpense(expenses).toLocaleString()}원`}
+          {`총 ${getTotalExpense(expenses ?? []).toLocaleString()}원`}
         </Button>
       </BottomButtonContainer>
     </FormProvider>

--- a/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
@@ -84,6 +84,22 @@ function ExpenseTimeHeader({
     }
   };
 
+  const prevPaidMemberRef = useRef(paidMember);
+
+  // 모든 멤버가 입금 완료된 "순간"에만 모달 표시
+  useEffect(() => {
+    if (
+      totalMember > 0 &&
+      paidMember === totalMember &&
+      prevPaidMemberRef.current < totalMember &&
+      !isChecked
+    ) {
+      setIsModalOpen(true);
+      setIsChecked(true);
+    }
+    prevPaidMemberRef.current = paidMember;
+  }, [paidMember, totalMember, isChecked, setIsChecked]);
+
   useEffect(() => {
     if (!headerData) return () => {};
 
@@ -99,26 +115,22 @@ function ExpenseTimeHeader({
         updateStatus('failure');
         stopTimer();
       } else {
-        if (totalMember === paidMember && !isChecked) {
-          setIsModalOpen(true);
-          setIsChecked(true);
-        }
         updateTimer(timeDifference);
       }
     }, 1000);
 
     return () => stopTimer(); // 컴포넌트 언마운트 시 타이머 멈추기
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headerData, totalMember, paidMember, isChecked]);
+  }, [headerData]);
 
   const handleModalButtonClick = () => {
+    stopTimer();
     setIsModalOpen(false);
     updateStatus('success');
     setHours(0);
     setMinutes(0);
     setSeconds(0);
     onShareClick();
-    stopTimer(); // 버튼 클릭 시 타이머 멈추기
   };
 
   if (isLoading) {

--- a/src/pages/groupSetup/GroupSetupPage.tsx
+++ b/src/pages/groupSetup/GroupSetupPage.tsx
@@ -2,6 +2,7 @@ import { useFunnel } from '@use-funnel/react-router';
 import { GroupNameSetupPage } from '@/pages/groupNameSetup';
 import { MemberSetupPage } from '@/pages/memberSetup';
 import { usePostCreateGroup } from '@/features/group-creation/api/usePostCreateGroup';
+import { showToast } from '@/shared/ui/Toast';
 
 // 모임 이름 입력 스텝에 필요한 context type
 type NameSetupType = {
@@ -35,8 +36,15 @@ function GroupSetupPage() {
         <GroupNameSetupPage
           onNext={async (groupName: string) => {
             if (isPending) return;
-            await createGroup({ name: groupName });
-            history.push('member', { groupName, password: '' });
+            try {
+              await createGroup({ name: groupName });
+              history.push('member', { groupName, password: '' });
+            } catch {
+              showToast({
+                type: 'error',
+                content: '모임 생성에 실패했어요. 다시 시도해 주세요.',
+              });
+            }
           }}
         />
       )}

--- a/src/pages/memberSetup/ui/AddMember/api/useAddGroupMember.ts
+++ b/src/pages/memberSetup/ui/AddMember/api/useAddGroupMember.ts
@@ -11,11 +11,11 @@ const useAddGroupMember = (
   const queryClient = useQueryClient();
 
   return useMutationWithHandlers({
-    mutationFn: groupMembers.put,
+    mutationFn: groupMembers.post,
     onSuccess: () => {
       // NOTE : 더 좋은 방법이 있을지 고민해봐야 할 것 같아요...
       queryClient.invalidateQueries({
-        queryKey: ['groupBasicInfo', groupToken],
+        queryKey: ['groupDetail', groupToken],
       });
     },
     errorHandlers,

--- a/src/pages/memberSetup/ui/AddMember/api/useDeleteGroupMember.ts
+++ b/src/pages/memberSetup/ui/AddMember/api/useDeleteGroupMember.ts
@@ -13,7 +13,7 @@ const useDeleteGroupMember = (
     mutationFn: groupMembers.delete,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['groupBasicInfo', groupToken],
+        queryKey: ['groupDetail', groupToken],
       });
     },
     errorHandlers,

--- a/src/pages/myLinks/MyLinksPage.tsx
+++ b/src/pages/myLinks/MyLinksPage.tsx
@@ -1,8 +1,9 @@
 import { useNavigate } from 'react-router';
 import { useTheme } from 'styled-components';
-import useGetExpensesLinks from '@/features/expense-management/api/useGetExpensesLinks';
+import useGetGroupLinks from '@/features/expense-management/api/useGetExpensesLinks';
 import { ArrowLeft } from '@/shared/assets/svgs/icon';
 import { ROUTE } from '@/shared/config/route';
+import generateShareLink from '@/shared/lib/generateShareLink';
 import Button from '@/shared/ui/Button';
 import Flex from '@/shared/ui/Flex';
 import Header from '@/shared/ui/Header';
@@ -12,7 +13,7 @@ import LinkBox from './ui/LinkBox';
 function MyLinksPage() {
   const navigate = useNavigate();
   const { color } = useTheme();
-  const { data, isLoading } = useGetExpensesLinks({}, []);
+  const { data: groupList, isLoading } = useGetGroupLinks({}, []);
 
   if (isLoading) {
     return (
@@ -50,7 +51,7 @@ function MyLinksPage() {
         onHeadingIconClick={() => navigate(-1)}
         bgColor={color.semantic.primary.subtle}
       />
-      {data?.links && data.links.length > 0 ? (
+      {groupList && groupList.length > 0 ? (
         <Flex
           pt={24}
           pb={22}
@@ -61,12 +62,12 @@ function MyLinksPage() {
           direction="column"
           bgColor={color.semantic.background.normal.alternative}
         >
-          {data.links.map((link) => (
+          {groupList.map((group) => (
             <LinkBox
-              key={link.id}
-              id={link.id}
-              name={link.name}
-              url={link.url}
+              key={group.settlementId}
+              id={group.settlementId}
+              name={group.name}
+              url={generateShareLink(group.groupCode)}
             />
           ))}
         </Flex>

--- a/src/shared/config/route.ts
+++ b/src/shared/config/route.ts
@@ -1,4 +1,4 @@
-export const BASE_URL = 'https://www.moddo.kr';
+export const BASE_URL = window.location.origin;
 
 export const ROUTE = {
   login: '/login',


### PR DESCRIPTION
## Summary
- 모든 API 엔드포인트를 `?groupToken=` 쿼리 파라미터 방식에서 `/groups/{code}/...` path 파라미터 방식으로 변경
- 존재하지 않는 모임 목록 조회 API(`GET /groups`) 및 관련 코드 제거
- 비밀번호 설정 스텝 제거, 모임 생성 시 `name`만 전달하도록 변경
- 비회원 로그인 버튼 제거, Lottie 컴포넌트 삭제
- 입금확인요청생성 API 연결 (`POST /groups/{code}/payments`)

## 변경된 엔드포인트

| Before | After |
|--------|-------|
| `GET /group?groupToken=xxx` | `GET /groups/{code}` |
| `POST /group` | `POST /groups` |
| `PUT /group/account?groupToken=xxx` | `PUT /groups/{code}/account` |
| `PUT /group-members?groupToken=xxx` | `POST /groups/{code}/members` |
| `DELETE /group-members/{id}?groupToken=xxx` | `DELETE /groups/{code}/members/{id}` |
| `GET /expenses?groupToken=xxx` | `GET /groups/{code}/expenses` |
| `POST /expenses?groupToken=xxx` | `POST /groups/{code}/expenses` |
| `DELETE /expenses/{id}?groupToken=xxx` | `DELETE /groups/{code}/expenses/{id}` |
| `PUT /expenses/{id}?groupToken=xxx` | `PUT /groups/{code}/expenses/{id}` |
| `GET /expenses/details?groupToken=xxx` | `GET /groups/{code}/expenses/details` |
| `GET /member-expenses?groupToken=xxx` | `GET /groups/{code}/member-expenses` |
| `PUT /group-members/{id}/payment?groupToken=xxx` | `PUT /groups/{code}/members/{id}/payment` |
| `GET /character?groupToken=xxx` | `GET /groups/{code}/character` |

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 생성 및 대기 상태 관리 기능이 추가되었습니다.

* **개선사항**
  * 그룹 생성 프로세스가 간소화되었습니다.
  * 로그인 페이지가 카카오 로그인으로만 제공됩니다.
  * API 엔드포인트 구조가 개선되었습니다.

* **제거된 기능**
  * 비회원 로그인 옵션이 제거되었습니다.
  * 그룹 목록 조회 기능이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->