### PR TITLE
정산 참여자 입금 확인 요청 로직 추가

### DIFF
--- a/src/pages/expenseDetail/ExpenseDetailPage.tsx
+++ b/src/pages/expenseDetail/ExpenseDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLoaderData, useNavigate } from 'react-router';
 import { useTheme } from 'styled-components';
 import { ArrowLeft } from '@/shared/assets/svgs/icon';
@@ -16,6 +16,7 @@ import { ROUTE } from '@/shared/config/route';
 import ShareButton from '@/shared/ui/ShareButton';
 import CharacterBottomSheet from '@/features/character-management/ui/CharacterBottomSheet';
 import useCreatePaymentRequest from '@/features/payment-management/api/useCreatePaymentRequest';
+import { useGetGroupHeader } from '@/features/settlement-details/api/useGetGroupHeader';
 import { showToast } from '@/shared/ui/Toast';
 import { TabsList, Tab } from './ui/Tabs';
 import ExpenseTimeline from './ui/ExpenseTimeline';
@@ -28,11 +29,29 @@ function ExpenseDetailPage() {
   const { unit, color } = useTheme();
   const [activeTab, setActiveTab] = useState('member');
   const { groupToken, groupData, myProfile } = useLoaderData();
-  const [status, setStatus] = useState<StatusType>('pending');
   const [openBottomSheet, setOpenBottomSheet] = useState<boolean>(false);
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState<boolean>(false);
   const { data: memberExpenseDetails } = useGetMemberExpenseDetails(groupToken);
+  const { data: headerData } = useGetGroupHeader(groupToken, {}, [401]);
   const [isChecked, setIsChecked] = useState<boolean>(false);
+
+  // TODO: GroupHeaderResponse에 completedAt 필드를 추가하여 서버에서 정산 완료 여부를 직접 내려받도록 개선 필요
+  const derivedStatus = useMemo<StatusType>(() => {
+    if (!memberExpenseDetails || !headerData) return 'pending';
+
+    const allPaid = memberExpenseDetails.every((member) => member.isPaid);
+    const isExpired = new Date(headerData.deadline).getTime() < Date.now();
+    if (allPaid) return 'success';
+    if (isExpired) return 'failure';
+
+    return 'pending';
+  }, [memberExpenseDetails, headerData]);
+
+  const [status, setStatus] = useState<StatusType>('pending');
+
+  useEffect(() => {
+    setStatus(derivedStatus);
+  }, [derivedStatus]);
   const navigate = useNavigate();
   const { mutate: createPaymentRequest } = useCreatePaymentRequest();
 

--- a/src/pages/expenseDetail/ExpenseDetailPage.tsx
+++ b/src/pages/expenseDetail/ExpenseDetailPage.tsx
@@ -37,15 +37,13 @@ function ExpenseDetailPage() {
 
   // TODO: GroupHeaderResponse에 completedAt 필드를 추가하여 서버에서 정산 완료 여부를 직접 내려받도록 개선 필요
   const derivedStatus = useMemo<StatusType>(() => {
-    if (!memberExpenseDetails || !headerData) return 'pending';
+    if (!headerData) return 'pending';
 
-    const allPaid = memberExpenseDetails.every((member) => member.isPaid);
     const isExpired = new Date(headerData.deadline).getTime() < Date.now();
-    if (allPaid) return 'success';
     if (isExpired) return 'failure';
 
     return 'pending';
-  }, [memberExpenseDetails, headerData]);
+  }, [headerData]);
 
   const [status, setStatus] = useState<StatusType>('pending');
 

--- a/src/pages/expenseDetail/ExpenseDetailPage.tsx
+++ b/src/pages/expenseDetail/ExpenseDetailPage.tsx
@@ -3,8 +3,11 @@ import { useLoaderData, useNavigate } from 'react-router';
 import { useTheme } from 'styled-components';
 import { ArrowLeft } from '@/shared/assets/svgs/icon';
 import Button from '@/shared/ui/Button';
+import ButtonGroup from '@/shared/ui/ButtonGroup';
 import Header from '@/shared/ui/Header';
 import Text from '@/shared/ui/Text';
+import Flex from '@/shared/ui/Flex';
+import Modal from '@/shared/ui/Modal';
 import { BottomButtonContainer } from '@/shared/styles/bottomButton.styles';
 import Divider from '@/shared/ui/Divider';
 import { useGetMemberExpenseDetails } from '@/features/expense-management/api/useGetMemberExpenseDetails';
@@ -12,6 +15,8 @@ import generateShareLink from '@/shared/lib/generateShareLink';
 import { ROUTE } from '@/shared/config/route';
 import ShareButton from '@/shared/ui/ShareButton';
 import CharacterBottomSheet from '@/features/character-management/ui/CharacterBottomSheet';
+import useCreatePaymentRequest from '@/features/payment-management/api/useCreatePaymentRequest';
+import { showToast } from '@/shared/ui/Toast';
 import { TabsList, Tab } from './ui/Tabs';
 import ExpenseTimeline from './ui/ExpenseTimeline';
 import ExpenseTimeHeader from './ui/ExpenseTimeHeader';
@@ -22,12 +27,26 @@ import * as S from './ExpenseDetailPage.styles';
 function ExpenseDetailPage() {
   const { unit, color } = useTheme();
   const [activeTab, setActiveTab] = useState('member');
-  const { groupToken, groupData } = useLoaderData();
+  const { groupToken, groupData, myProfile } = useLoaderData();
   const [status, setStatus] = useState<StatusType>('pending');
   const [openBottomSheet, setOpenBottomSheet] = useState<boolean>(false);
+  const [isPaymentModalOpen, setIsPaymentModalOpen] = useState<boolean>(false);
   const { data: memberExpenseDetails } = useGetMemberExpenseDetails(groupToken);
   const [isChecked, setIsChecked] = useState<boolean>(false);
   const navigate = useNavigate();
+  const { mutate: createPaymentRequest } = useCreatePaymentRequest();
+
+  const handlePaymentRequest = () => {
+    createPaymentRequest(groupToken, {
+      onSuccess: () => {
+        setIsPaymentModalOpen(false);
+        showToast({
+          type: 'success',
+          content: '입금 확인 요청이 전송되었습니다.',
+        });
+      },
+    });
+  };
 
   let MEMBER_TOTAL = 0;
   let MEMBER_DONE = 0;
@@ -84,19 +103,64 @@ function ExpenseDetailPage() {
         )}
       </S.Content>
       <BottomButtonContainer>
-        {/* eslint-disable-next-line */}
-        {MEMBER_TOTAL === MEMBER_DONE && status === 'pending' ? (
+        {/* eslint-disable no-nested-ternary */}
+        {MEMBER_TOTAL === MEMBER_DONE &&
+        status === 'pending' &&
+        myProfile.role === 'MANAGER' ? (
           <Button onClick={() => setIsChecked(false)}>정산 완료하기</Button>
+        ) : status === 'pending' && myProfile.role === 'PARTICIPANT' ? (
+          <Button onClick={() => setIsPaymentModalOpen(true)}>
+            입금 확인 요청
+          </Button>
         ) : status === 'success' ? (
           <Button onClick={handleBackToHome}>홈으로 돌아가기</Button>
         ) : (
           <ShareButton shareLink={shareLink} />
         )}
+        {/* eslint-enable no-nested-ternary */}
       </BottomButtonContainer>
       <CharacterBottomSheet
         open={openBottomSheet}
         setOpen={setOpenBottomSheet}
       />
+      <Modal
+        open={isPaymentModalOpen}
+        setOpen={setIsPaymentModalOpen}
+        variant="empty"
+      >
+        <Flex direction="column" gap={28} style={{ width: '100%' }}>
+          <Flex direction="column" gap={16}>
+            <Text
+              variant="title"
+              color="semantic.text.strong"
+              style={{ whiteSpace: 'pre-line' }}
+            >
+              <Text variant="title" color="semantic.orange.default" as="span">
+                {myProfile.name}
+              </Text>
+              {'님의\n정산 입금을 알릴게요.'}
+            </Text>
+            <Text
+              variant="body1R"
+              color="semantic.text.strong"
+              style={{ whiteSpace: 'pre-line' }}
+            >
+              {
+                '총무에게 입금 확인 요청 알림이 전송됩니다.\n입금을 완료했을 때만 눌러주세요.'
+              }
+            </Text>
+          </Flex>
+          <ButtonGroup direction="horizontal">
+            <Button
+              variant="secondary"
+              onClick={() => setIsPaymentModalOpen(false)}
+            >
+              취소
+            </Button>
+            <Button onClick={handlePaymentRequest}>알림 보내기</Button>
+          </ButtonGroup>
+        </Flex>
+      </Modal>
     </>
   );
 }

--- a/src/pages/expenseDetail/ExpenseDetailPage.tsx
+++ b/src/pages/expenseDetail/ExpenseDetailPage.tsx
@@ -13,7 +13,6 @@ import Divider from '@/shared/ui/Divider';
 import { useGetMemberExpenseDetails } from '@/features/expense-management/api/useGetMemberExpenseDetails';
 import generateShareLink from '@/shared/lib/generateShareLink';
 import { ROUTE } from '@/shared/config/route';
-import ShareButton from '@/shared/ui/ShareButton';
 import CharacterBottomSheet from '@/features/character-management/ui/CharacterBottomSheet';
 import useCreatePaymentRequest from '@/features/payment-management/api/useCreatePaymentRequest';
 import { useGetGroupHeader } from '@/features/settlement-details/api/useGetGroupHeader';
@@ -23,6 +22,7 @@ import ExpenseTimeline from './ui/ExpenseTimeline';
 import ExpenseTimeHeader from './ui/ExpenseTimeHeader';
 import ExpenseMembers from './ui/ExpenseMembers';
 import { StatusType } from './ui/ExpenseTimeHeader/index.type';
+import BottomAction from './ui/BottomAction';
 import * as S from './ExpenseDetailPage.styles';
 
 function ExpenseDetailPage() {
@@ -120,21 +120,16 @@ function ExpenseDetailPage() {
         )}
       </S.Content>
       <BottomButtonContainer>
-        {/* eslint-disable no-nested-ternary */}
-        {MEMBER_TOTAL === MEMBER_DONE &&
-        status === 'pending' &&
-        myProfile.role === 'MANAGER' ? (
-          <Button onClick={() => setIsChecked(false)}>정산 완료하기</Button>
-        ) : status === 'pending' && myProfile.role === 'PARTICIPANT' ? (
-          <Button onClick={() => setIsPaymentModalOpen(true)}>
-            입금 확인 요청
-          </Button>
-        ) : status === 'success' ? (
-          <Button onClick={handleBackToHome}>홈으로 돌아가기</Button>
-        ) : (
-          <ShareButton shareLink={shareLink} />
-        )}
-        {/* eslint-enable no-nested-ternary */}
+        <BottomAction
+          status={status}
+          myProfile={myProfile}
+          memberTotal={MEMBER_TOTAL}
+          memberDone={MEMBER_DONE}
+          shareLink={shareLink}
+          onSettleClick={() => setIsChecked(false)}
+          onPaymentRequestClick={() => setIsPaymentModalOpen(true)}
+          onBackToHome={handleBackToHome}
+        />
       </BottomButtonContainer>
       <CharacterBottomSheet
         open={openBottomSheet}

--- a/src/pages/expenseDetail/ui/BottomAction/index.tsx
+++ b/src/pages/expenseDetail/ui/BottomAction/index.tsx
@@ -1,0 +1,47 @@
+import Button from '@/shared/ui/Button';
+import ShareButton from '@/shared/ui/ShareButton';
+import { MemberProfile } from '@/entities/member/model/member.type';
+import { StatusType } from '../ExpenseTimeHeader/index.type';
+
+interface BottomActionProps {
+  status: StatusType;
+  myProfile: MemberProfile;
+  memberTotal: number;
+  memberDone: number;
+  shareLink: string;
+  onSettleClick: () => void;
+  onPaymentRequestClick: () => void;
+  onBackToHome: () => void;
+}
+
+function BottomAction({
+  status,
+  myProfile,
+  memberTotal,
+  memberDone,
+  shareLink,
+  onSettleClick,
+  onPaymentRequestClick,
+  onBackToHome,
+}: BottomActionProps) {
+  if (status === 'success') {
+    return <Button onClick={onBackToHome}>홈으로 돌아가기</Button>;
+  }
+
+  // status === 'pending'
+  if (myProfile.role === 'MANAGER' && memberTotal === memberDone) {
+    return <Button onClick={onSettleClick}>정산 완료하기</Button>;
+  }
+
+  if (myProfile.role === 'PARTICIPANT' && !myProfile.isPaid) {
+    return <Button onClick={onPaymentRequestClick}>입금 확인 요청</Button>;
+  }
+
+  if (myProfile.role === 'PARTICIPANT' && myProfile.isPaid) {
+    return <Button disabled>정산 완료</Button>;
+  }
+
+  return <ShareButton shareLink={shareLink} />;
+}
+
+export default BottomAction;

--- a/src/pages/expenseDetail/ui/ExpenseMemberItem/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseMemberItem/index.tsx
@@ -60,6 +60,8 @@ function ExpenseMemberItem({
     setOpen(false);
   };
 
+  // TODO: role에 따라 상태 변경 버튼 클릭 가능 여부 체크
+
   return (
     <S.Container isPaid={member.isPaid}>
       <S.HeaderContainer iconSize={32}>

--- a/src/pages/expenseDetail/ui/ExpenseMemberItem/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseMemberItem/index.tsx
@@ -9,6 +9,7 @@ import BottomSheet from '@/shared/ui/BottomSheet';
 import { MemberSettlement } from '@/entities/settlement/model/settlement.type';
 import useUpdatePaymentStatus from '@/features/settlement-details/api/useUpdatePaymentStatus';
 import ProfileImage from '@/shared/ui/ProfileImage';
+import { useLoaderData } from 'react-router';
 import * as S from './index.style';
 import StatusChip from './ui/StatusChip';
 
@@ -27,6 +28,7 @@ function ExpenseMemberItem({
   const [open, setOpen] = useState<boolean>(false);
   const [isPaid, setIsPaid] = useState<boolean>(member.isPaid);
   const [isConfirm, setIsConfirm] = useState<boolean>(false);
+  const { myProfile } = useLoaderData();
   const theme = useTheme();
   const updatePaymentStatusMutation = useUpdatePaymentStatus({
     groupToken,
@@ -61,6 +63,9 @@ function ExpenseMemberItem({
   };
 
   // TODO: role에 따라 상태 변경 버튼 클릭 가능 여부 체크
+  const handleStatusChipClick = () => {
+    if (myProfile.role === 'MANAGER') setOpen(true);
+  };
 
   return (
     <S.Container isPaid={member.isPaid}>
@@ -81,7 +86,7 @@ function ExpenseMemberItem({
           </S.LeftWrapper>
           <S.RightWrapper>
             <S.StatusChipButton
-              onClick={() => setOpen(true)}
+              onClick={handleStatusChipClick}
               aria-label={`${member.name}의 정산 상태 변경`}
             >
               <StatusChip status={member.isPaid ? 'paid' : 'unpaid'} />

--- a/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
@@ -102,14 +102,13 @@ function ExpenseTimeHeader({
   }, [paidMember, totalMember, isChecked, setIsChecked]);
 
   useEffect(() => {
-    if (!headerData) return () => {};
+    if (!headerData || status !== 'pending') return () => {};
 
     intervalRef.current = setInterval(() => {
       const now = new Date();
       const endDate = new Date(headerData!.deadline);
       const timeDifference = endDate.getTime() - now.getTime();
       if (timeDifference <= 0) {
-        if (status === 'success') return;
         setHours(0);
         setMinutes(0);
         setSeconds(0);
@@ -122,7 +121,7 @@ function ExpenseTimeHeader({
 
     return () => stopTimer(); // 컴포넌트 언마운트 시 타이머 멈추기
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [headerData]);
+  }, [headerData, status]);
 
   const handleModalButtonClick = () => {
     stopTimer();

--- a/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
@@ -86,6 +86,7 @@ function ExpenseTimeHeader({
 
   const prevPaidMemberRef = useRef(paidMember);
 
+  // TODO: isChecked를 sessionStorage/localStorage로 관리하여 새로고침 시에도 모달이 다시 뜨지 않도록 개선 필요 (groupToken별 키 사용)
   // 모든 멤버가 입금 완료된 "순간"에만 모달 표시
   useEffect(() => {
     if (

--- a/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
+++ b/src/pages/expenseDetail/ui/ExpenseTimeHeader/index.tsx
@@ -84,21 +84,13 @@ function ExpenseTimeHeader({
     }
   };
 
-  const prevPaidMemberRef = useRef(paidMember);
-
   // TODO: isChecked를 sessionStorage/localStorage로 관리하여 새로고침 시에도 모달이 다시 뜨지 않도록 개선 필요 (groupToken별 키 사용)
   // 모든 멤버가 입금 완료된 "순간"에만 모달 표시
   useEffect(() => {
-    if (
-      totalMember > 0 &&
-      paidMember === totalMember &&
-      prevPaidMemberRef.current < totalMember &&
-      !isChecked
-    ) {
+    if (totalMember > 0 && paidMember === totalMember && !isChecked) {
       setIsModalOpen(true);
       setIsChecked(true);
     }
-    prevPaidMemberRef.current = paidMember;
   }, [paidMember, totalMember, isChecked, setIsChecked]);
 
   useEffect(() => {

--- a/src/pages/home/ui/HomeExpenseItem/index.tsx
+++ b/src/pages/home/ui/HomeExpenseItem/index.tsx
@@ -1,5 +1,6 @@
 import { DollarCircle } from '@/shared/assets/svgs/icon';
 import { useTheme } from 'styled-components';
+import { useNavigate } from 'react-router';
 import Text from '@/shared/ui/Text';
 import Flex from '@/shared/ui/Flex';
 import DefaultProgressBar from '../DefaultProgressBar';
@@ -7,6 +8,7 @@ import * as S from './index.style';
 
 interface HomeExpenseItemProps {
   date: string;
+  groupCode: string;
   groupName: string;
   totalAmount: number;
   paidMember: number;
@@ -15,16 +17,22 @@ interface HomeExpenseItemProps {
 
 function HomeExpenseItem({
   date,
+  groupCode,
   groupName,
   totalAmount,
   paidMember,
   totalMember,
 }: HomeExpenseItemProps) {
   const theme = useTheme();
+  const navigate = useNavigate();
   const percentage = (paidMember / totalMember) * 100;
 
+  // TODO: 디자이너 확인 후 클릭 시 정산 상세 페이지 이동 UX 확정 필요
   return (
-    <S.Wrapper>
+    <S.Wrapper
+      onClick={() => navigate(`/expense-detail/${groupCode}`)}
+      style={{ cursor: 'pointer' }}
+    >
       <Text variant="body1Sb" color="semantic.text.default">
         {date}
       </Text>

--- a/src/pages/home/ui/HomePageSection/index.tsx
+++ b/src/pages/home/ui/HomePageSection/index.tsx
@@ -43,7 +43,7 @@ export function MainHeader() {
       // TODO: 알림 기능 개발 후 onTrailingIconClick 핸들러 연결
       trailingSubIcon={<Menu width={24} height={24} />}
       onTrailingSubIconClick={() => navigate(ROUTE.my)}
-      bgColor="semantic.background.normal.alternative"
+      bgColor={theme.color.semantic.background.normal.default}
     />
   );
 }

--- a/src/pages/home/ui/HomePageSection/index.tsx
+++ b/src/pages/home/ui/HomePageSection/index.tsx
@@ -145,40 +145,42 @@ function SettlementContent({
       </Flex>
     );
   }
-  if (settlementList.length > 0) {
+  if (settlementList.length === 0) {
     return (
-      <S.SettlementListWrapper>
-        {settlementList.map((item) => (
-          <HomeExpenseItem
-            key={item.groupId}
-            date={format(new Date(item.createdAt), 'yyyy년 M월 d일', {
-              locale: ko,
-            })}
-            groupName={item.name}
-            totalAmount={item.totalAmount}
-            paidMember={item.completedMemberCount}
-            totalMember={item.totalMemberCount}
-          />
-        ))}
-      </S.SettlementListWrapper>
+      <Flex
+        direction="column"
+        py={20}
+        justifyContent="center"
+        alignItems="center"
+        flexGrow={1}
+        gap={20}
+      >
+        <S.NoSettlementImg src={CoinImg} alt="" />
+        <Text variant="body2R" color="semantic.text.subtle">
+          {settlementType === 'IN_PROGRESS'
+            ? '아직 진행중인 정산이 없어요.'
+            : '완료된 정산이 없어요.'}
+        </Text>
+      </Flex>
     );
   }
+
   return (
-    <Flex
-      direction="column"
-      py={20}
-      justifyContent="center"
-      alignItems="center"
-      flexGrow={1}
-      gap={20}
-    >
-      <S.NoSettlementImg src={CoinImg} alt="" />
-      <Text variant="body2R" color="semantic.text.subtle">
-        {settlementType === 'IN_PROGRESS'
-          ? '아직 진행중인 정산이 없어요.'
-          : '완료된 정산이 없어요.'}
-      </Text>
-    </Flex>
+    <S.SettlementListWrapper>
+      {settlementList.map((item) => (
+        <HomeExpenseItem
+          key={item.groupId}
+          groupCode={item.groupCode}
+          date={format(new Date(item.createdAt), 'yyyy년 M월 d일', {
+            locale: ko,
+          })}
+          groupName={item.name}
+          totalAmount={item.totalAmount}
+          paidMember={item.completedMemberCount}
+          totalMember={item.totalMemberCount}
+        />
+      ))}
+    </S.SettlementListWrapper>
   );
 }
 


### PR DESCRIPTION
## Summary
- 참여자(PARTICIPANT) 역할일 때 "입금 확인 요청" 버튼 및 모달 추가, `POST /groups/{code}/payments` API 연결
- 새로고침 시 정산 완료/마감 상태가 유지되도록 `derivedStatus` 기반 초기 상태 계산 로직 도입
- 정산 내역 아이템 클릭 시 정산 상세 페이지로 이동하는 네비게이션 추가
- MainHeader bgColor를 theme 객체 참조로 변경

## Changes
- `ExpenseDetailPage`: role 기반 하단 버튼 분기 (MANAGER/PARTICIPANT), 입금 확인 요청 모달 UI 및 API 연결, derivedStatus로 초기 상태 복원
- `ExpenseTimeHeader`: status가 pending일 때만 타이머 실행
- `HomeExpenseItem`: groupCode prop 추가 및 클릭 시 정산 상세 페이지 이동 (디자이너 확인 필요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 결제 요청 알림 기능 추가: 참여자가 입금 확인을 요청할 수 있습니다.

* **Improvements**
  * 역할 기반 액션: 관리자와 참여자에게 적절한 버튼을 표시합니다.
  * 항목별 상세 페이지 이동: 정산 내역을 더 편하게 확인할 수 있습니다.
  * 완료 상태 자동 감지: 서버 기반 정확한 상태 반영으로 신뢰성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->