### PR TITLE
Cloudflare Pages 프록시로 CORS 우회

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+/api/v1/* https://api.moddo.kr/api/v1/:splat 200

--- a/src/shared/api/axios.ts
+++ b/src/shared/api/axios.ts
@@ -1,11 +1,8 @@
 import axios, { AxiosHeaders, isAxiosError } from 'axios';
 import { ROUTE } from '@/shared/config/route';
 
-// 개발 환경에서는 Vite proxy(/api/v1)를 경유해 cross-origin 쿠키 차단을 우회 (참고: vite.config.ts의 server.proxy 설정)
-// 프로덕션에서는 VITE_SERVER_URL로 직접 요청
-const BASE_URL = import.meta.env.DEV
-  ? '/api/v1'
-  : `${import.meta.env.VITE_SERVER_URL ?? ''}/api/v1`;
+// 개발: Vite proxy, 프로덕션: Cloudflare Pages proxy (_redirects)
+const BASE_URL = '/api/v1';
 
 const axiosInstance = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
## Summary
- `public/_redirects` 추가하여 프로덕션에서 `/api/v1/*` 요청을 `api.moddo.kr`로 프록시
- `BASE_URL`을 환경 분기 없이 `/api/v1`로 통일 (개발: Vite proxy, 프로덕션: Cloudflare Pages proxy)
- 배포 환경에서 발생하던 CORS 403 에러 해결

## Test plan
- [ ] 배포 후 `https://moddo-frontend.pages.dev`에서 API 요청이 정상 동작하는지 확인
- [ ] 개발 환경에서 Vite proxy가 여전히 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)