### PR TITLE
Storybook 수동 배포 설정과 프로덕션 브랜치 main으로 재변경

### DIFF
--- a/.github/workflows/prod-ci-cd.yml
+++ b/.github/workflows/prod-ci-cd.yml
@@ -1,13 +1,12 @@
 name: PROD CI CD Preview
 
-# TODO: 추후 main 브랜치에 push 될 때마다 action이 실행되도록 수정 필요
 on: # develop 브랜치에 pr, push 될 때마다 action이 실행됩니다.
   push:
     branches:
-      - develop
+      - main
   pull_request:
     branches:
-      - develop
+      - main
 
 jobs:
   ci:

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -2,6 +2,7 @@ name: Publish Storybook
 # https://www.chromatic.com/docs/github-actions/
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize]
     branches:
@@ -42,6 +43,7 @@ jobs:
         if: steps.chromatic.outputs.changeCount != '0'
         uses: thollander/actions-comment-pull-request@v3
         with:
+          comment-tag: chromatic-storybook
           message: |
             ✨ Storybook
             👉 ${{ steps.chromatic.outputs.storybookUrl }}
@@ -53,6 +55,7 @@ jobs:
         if: steps.chromatic.outputs.changeCount == '0'
         uses: thollander/actions-comment-pull-request@v3
         with:
+          comment-tag: chromatic-storybook
           message: |
             ✨ Storybook
             👉 ${{ steps.chromatic.outputs.storybookUrl }}


### PR DESCRIPTION
## 💻 작업 내용

stacked PR에서도 Storybook 배포가 필요할 때 수동 실행할 수 있도록 workflow_dispatch를 추가했습니다.

- Chromatic Storybook 배포 워크플로에 수동 실행 트리거를 추가했습니다.
- Storybook 배포 코멘트가 매번 새로 쌓이지 않고 기존 코멘트를 갱신하도록 comment-tag를 설정했습니다.

#46 에서 임시로 변경했던 프로덕션 배포 브랜치도 다시 main으로 수정했습니다!

## ✅ 테스트 리스트 (선택)

- [ ] GitHub Actions에서 Publish Storybook 수동 실행 확인

## 👻 리뷰 요구사항

바로 스토리북 배포가 필요해서 이 PR은 승인 없이 머지하겠습니다 ... !