### PR TITLE
Storybook 수동 배포 코멘트 대상 설정 추가

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -3,6 +3,11 @@ name: Publish Storybook
 
 on:
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Storybook URL을 코멘트할 PR 번호'
+        required: false
+        type: string
   pull_request:
     types: [opened, synchronize]
     branches:
@@ -40,9 +45,10 @@ jobs:
           onlyChanged: true # Only run Chromatic on changed stories
 
       - name: Comment on PR (with snapshot changes)
-        if: steps.chromatic.outputs.changeCount != '0'
+        if: steps.chromatic.outputs.changeCount != '0' && (github.event_name == 'pull_request' || inputs.pr_number != '')
         uses: thollander/actions-comment-pull-request@v3
         with:
+          pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
           comment-tag: chromatic-storybook
           message: |
             ✨ Storybook
@@ -52,9 +58,10 @@ jobs:
             👉 ${{ steps.chromatic.outputs.buildUrl }}
 
       - name: Comment on PR (no snapshot changes)
-        if: steps.chromatic.outputs.changeCount == '0'
+        if: steps.chromatic.outputs.changeCount == '0' && (github.event_name == 'pull_request' || inputs.pr_number != '')
         uses: thollander/actions-comment-pull-request@v3
         with:
+          pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
           comment-tag: chromatic-storybook
           message: |
             ✨ Storybook


### PR DESCRIPTION
## 💻 작업 내용

#50 에서 추가한 Storybook 수동 배포를 실행했을 때 target PR을 찾지 못해서 코멘트 다는 것이 실패하는 문제가 있었습니다... Storybook 수동 배포 시 코멘트를 남길 PR 번호를 입력할 수 있도록 `workflow_dispatch` input을 추가했습니다.

> 참고: 수동 실행 시 입력 폼은 선택한 브랜치의 `publish-storybook.yml`을 기준으로 표시됩니다! 따라서 배포 대상 브랜치에도 `pr_number` input이 포함된 워크플로가 반영되어 있어야 합니다.

## ✅ 테스트 리스트

- [x] `gh workflow run publish-storybook.yml --ref chore/storybook-dispatch-comment -f pr_number=<PR_NUMBER>`로 수동 실행 확인 (#49 에서 확인함)

## 👻 리뷰 요구사항

이것도 동일하게 빠른 후속 작업을 위해서 승인 생략하고 머지하겠습니다..!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Storybook 배포 워크플로우를 수동 트리거 기능으로 개선했습니다. 선택적 PR 번호 입력 파라미터를 추가하여 더 유연한 배포 프로세스를 지원합니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moddo-kr/moddo-frontend/pull/51)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->