### PR TITLE
정산 상세 관리 메뉴에 계좌 수정 기능 추가

### DIFF
--- a/src/_workspace/AccountEditDialog/AccountEditDialog.tsx
+++ b/src/_workspace/AccountEditDialog/AccountEditDialog.tsx
@@ -1,0 +1,65 @@
+import type { ChangeEventHandler } from 'react';
+import { Dialog, Input, Modal } from '@/shared/design-system/ui';
+import { Dropdown, type DropdownOption } from '../Dropdown';
+
+interface AccountEditDialogProps {
+  open: boolean;
+  bankOptions: DropdownOption[];
+  bankValue: string;
+  bankPlaceholder?: string;
+  onBankChange: (value: string) => void;
+  accountNumber: string;
+  accountNumberPlaceholder?: string;
+  onAccountNumberChange: ChangeEventHandler<HTMLInputElement>;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function AccountEditDialog(props: AccountEditDialogProps) {
+  const {
+    open,
+    bankOptions,
+    bankValue,
+    bankPlaceholder = '은행을 선택해주세요',
+    onBankChange,
+    accountNumber,
+    accountNumberPlaceholder = '계좌 번호를 입력해주세요',
+    onAccountNumberChange,
+    onCancel,
+    onConfirm,
+  } = props;
+
+  const isConfirmDisabled = !bankValue || !accountNumber;
+
+  return (
+    <Modal open={open} onClose={onCancel} ariaLabel="계좌 수정">
+      <Dialog
+        title="계좌 수정"
+        description="정산 받을 계좌를 입력해주세요."
+        mainAction={{
+          label: '확인',
+          onClick: onConfirm,
+          disabled: isConfirmDisabled,
+        }}
+        alternativeAction={{ label: '취소', onClick: onCancel }}
+      >
+        <Dropdown
+          label="은행 선택"
+          options={bankOptions}
+          value={bankValue}
+          onChange={onBankChange}
+          placeholder={bankPlaceholder}
+        />
+        <Input
+          label="계좌 번호"
+          placeholder={accountNumberPlaceholder}
+          value={accountNumber}
+          onChange={onAccountNumberChange}
+        />
+      </Dialog>
+    </Modal>
+  );
+}
+
+export { AccountEditDialog };
+export type { AccountEditDialogProps };

--- a/src/_workspace/AccountEditDialog/index.ts
+++ b/src/_workspace/AccountEditDialog/index.ts
@@ -1,0 +1,2 @@
+export { AccountEditDialog } from './AccountEditDialog';
+export type { AccountEditDialogProps } from './AccountEditDialog';

--- a/src/_workspace/Dropdown/Dropdown.styles.ts
+++ b/src/_workspace/Dropdown/Dropdown.styles.ts
@@ -1,0 +1,130 @@
+import styled, { css } from 'styled-components';
+import { getToken, applyTypography } from '@/shared/design-system';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: ${getToken('gap.4')};
+  width: 100%;
+`;
+
+export const Label = styled.span`
+  ${applyTypography('typography.body.small-semibold')}
+  color: ${getToken('fg.neutral')};
+`;
+
+export const TriggerWrap = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+export const Trigger = styled.button<{ $isOpen: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${getToken('gap.4')};
+  width: 100%;
+  padding: ${getToken('padding.4')} ${getToken('padding.5')};
+  background: ${getToken('fill.normal')};
+  border-radius: ${getToken('radius.lg')};
+  cursor: pointer;
+  ${({ $isOpen }) =>
+    $isOpen
+      ? css`
+          border: 2px solid ${getToken('border.primary.normal')};
+        `
+      : css`
+          border: 1px solid ${getToken('border.neutral')};
+        `}
+`;
+
+export const ValueText = styled.span<{ $isPlaceholder: boolean }>`
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  ${applyTypography('typography.body.medium')}
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  ${({ $isPlaceholder }) =>
+    $isPlaceholder
+      ? css`
+          color: ${getToken('fg.assistive')};
+          opacity: 0.5;
+        `
+      : css`
+          color: ${getToken('fg.normal')};
+        `}
+`;
+
+export const ChevronWrapper = styled.span<{ $isOpen: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: ${getToken('fg.assistive')};
+  transform: ${({ $isOpen }) => ($isOpen ? 'rotate(180deg)' : 'rotate(0deg)')};
+  transition: transform 0.2s ease-in-out;
+`;
+
+export const Panel = styled.div`
+  position: absolute;
+  top: calc(100% + ${getToken('gap.3')});
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${getToken('gap.1')};
+  background: ${getToken('fill.normal')};
+  border: 1px solid ${getToken('border.alternative')};
+  border-radius: ${getToken('radius.md')};
+  padding: ${getToken('padding.3')};
+  /* HACK: shadow2(0px 4px 8px rgba(0,0,0,0.12)) 매핑되는 shadow 시맨틱 토큰 없음 */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.12);
+  /* HACK: 옵션이 많을 때 패널이 넘치지 않도록 max-height 제한. 대응 토큰 없어 직접 사용. */
+  max-height: 240px;
+  overflow-y: auto;
+  z-index: 10;
+`;
+
+export const OptionItem = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: ${getToken('gap.6')};
+  width: 100%;
+  padding: ${getToken('padding.3')};
+  border-radius: ${getToken('radius.sm')};
+  background: transparent;
+  border: none;
+  cursor: pointer;
+
+  &:hover,
+  &:active {
+    background: ${getToken('fill.normal-pressed')};
+  }
+`;
+
+export const OptionLabel = styled.span<{ $isSelected: boolean }>`
+  ${({ $isSelected }) =>
+    $isSelected
+      ? applyTypography('typography.body.medium-semibold')
+      : applyTypography('typography.body.medium')}
+  color: ${({ $isSelected }) =>
+    $isSelected ? getToken('fg.primary.normal') : getToken('fg.normal')};
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+  white-space: nowrap;
+`;
+
+export const ConfirmIconWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: ${getToken('fg.primary.normal')};
+
+  svg path {
+    stroke: currentColor;
+  }
+`;

--- a/src/_workspace/Dropdown/Dropdown.tsx
+++ b/src/_workspace/Dropdown/Dropdown.tsx
@@ -1,0 +1,104 @@
+import { useState, useRef, useEffect, useId } from 'react';
+import SvgArrowDown from '@/shared/assets/svgs/icon/ArrowDown';
+import SvgConfirm from '@/shared/assets/svgs/icon/Confirm';
+import * as S from './Dropdown.styles';
+
+interface DropdownOption {
+  label: string;
+  value: string;
+}
+
+interface DropdownProps {
+  label?: string;
+  options: DropdownOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+function Dropdown(props: DropdownProps) {
+  const { label, options, value, onChange, placeholder = '선택' } = props;
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const listboxId = useId();
+
+  const selectedOption = options.find((option) => option.value === value);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    function handleOutsideClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  function handleOptionClick(optionValue: string) {
+    onChange(optionValue);
+    setIsOpen(false);
+  }
+
+  return (
+    <S.Container ref={containerRef}>
+      {label && <S.Label>{label}</S.Label>}
+      <S.TriggerWrap>
+        <S.Trigger
+          type="button"
+          $isOpen={isOpen}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-controls={isOpen ? listboxId : undefined}
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          <S.ValueText $isPlaceholder={!selectedOption}>
+            {selectedOption?.label ?? placeholder}
+          </S.ValueText>
+          <S.ChevronWrapper $isOpen={isOpen}>
+            <SvgArrowDown width={24} height={24} />
+          </S.ChevronWrapper>
+        </S.Trigger>
+        {isOpen && (
+          <S.Panel id={listboxId} role="listbox">
+            {options.map((option) => (
+              <S.OptionItem
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={option.value === value}
+                onClick={() => handleOptionClick(option.value)}
+              >
+                <S.OptionLabel $isSelected={option.value === value}>
+                  {option.label}
+                </S.OptionLabel>
+                {option.value === value && (
+                  <S.ConfirmIconWrapper>
+                    <SvgConfirm width={14} height={10} />
+                  </S.ConfirmIconWrapper>
+                )}
+              </S.OptionItem>
+            ))}
+          </S.Panel>
+        )}
+      </S.TriggerWrap>
+    </S.Container>
+  );
+}
+
+export { Dropdown };
+export type { DropdownProps, DropdownOption };

--- a/src/_workspace/Dropdown/index.ts
+++ b/src/_workspace/Dropdown/index.ts
@@ -1,0 +1,2 @@
+export { Dropdown } from './Dropdown';
+export type { DropdownProps, DropdownOption } from './Dropdown';

--- a/src/pages/expenseDetail/ui/ManageMenu/index.tsx
+++ b/src/pages/expenseDetail/ui/ManageMenu/index.tsx
@@ -1,10 +1,20 @@
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { Dimmed, Dialog, Modal, showToast } from '@/shared/design-system/ui';
 import payment from '@/entities/payment/api/payment';
+import usePutUpdateAccount from '@/features/expense-management/api/usePutUpdateAccount';
 import { ROUTE } from '@/shared/config/route';
+import { BoundaryError } from '@/shared/types/error.type';
+import { AccountEditDialog } from '@/_workspace/AccountEditDialog';
+import BANK_LIST from '@/pages/addAccountStep/ui/BankNameDrawer/config/banks';
 import * as S from './index.styles';
+
+const BANK_OPTIONS = BANK_LIST.map((bank) => ({
+  label: bank.bankName,
+  value: bank.bankName,
+}));
 
 interface ManageMenuProps {
   groupToken: string;
@@ -14,7 +24,26 @@ function ManageMenu({ groupToken }: ManageMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isBlockedModalOpen, setIsBlockedModalOpen] = useState(false);
   const [isPending, setIsPending] = useState(false);
+  const [isAccountEditOpen, setIsAccountEditOpen] = useState(false);
+  const [bankName, setBankName] = useState('');
+  const [accountNumber, setAccountNumber] = useState('');
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const { mutate: updateAccountMutate } = usePutUpdateAccount(
+    groupToken,
+    {
+      // CHECK - 문서에는 403 에러로 되어 있지만, 실제로는 500 에러가 발생함
+      // 유저가 모임 총무가 아닐 경우에 발생하는 에러
+      403: () => {
+        throw new BoundaryError({
+          title: '접근 권한이 없어요.',
+          description: '계좌는 총무만 수정할 수 있어요.',
+        });
+      },
+    },
+    [403]
+  );
 
   const handleEditExpenses = async () => {
     setIsOpen(false);
@@ -36,6 +65,29 @@ function ManageMenu({ groupToken }: ManageMenuProps) {
     }
   };
 
+  const handleOpenAccountEdit = () => {
+    setIsOpen(false);
+    setIsAccountEditOpen(true);
+  };
+
+  const handleAccountEditConfirm = () => {
+    updateAccountMutate(
+      {
+        accountData: { bank: bankName, accountNumber },
+        groupToken,
+      },
+      {
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: ['groupHeader', groupToken],
+          });
+          showToast({ type: 'success', content: '계좌를 수정했어요.' });
+          setIsAccountEditOpen(false);
+        },
+      }
+    );
+  };
+
   return (
     <>
       <S.TriggerButton onClick={() => setIsOpen(true)} disabled={isPending}>
@@ -49,12 +101,23 @@ function ManageMenu({ groupToken }: ManageMenuProps) {
               <S.MenuItemButton onClick={handleEditExpenses}>
                 정산 내역 수정
               </S.MenuItemButton>
-              {/* TODO: 계좌 수정 기능 구현 시 연결 */}
-              <S.MenuItemButton disabled>계좌 수정</S.MenuItemButton>
+              <S.MenuItemButton onClick={handleOpenAccountEdit}>
+                계좌 수정
+              </S.MenuItemButton>
             </S.MenuCard>
           </>,
           document.querySelector('#modal') ?? document.body
         )}
+      <AccountEditDialog
+        open={isAccountEditOpen}
+        bankOptions={BANK_OPTIONS}
+        bankValue={bankName}
+        onBankChange={setBankName}
+        accountNumber={accountNumber}
+        onAccountNumberChange={(e) => setAccountNumber(e.target.value)}
+        onCancel={() => setIsAccountEditOpen(false)}
+        onConfirm={handleAccountEditConfirm}
+      />
       <Modal
         open={isBlockedModalOpen}
         onClose={() => setIsBlockedModalOpen(false)}

--- a/src/shared/design-system/ui/Dialog/Dialog.styles.ts
+++ b/src/shared/design-system/ui/Dialog/Dialog.styles.ts
@@ -16,6 +16,19 @@ export const Container = styled.div`
   max-width: 330px;
 `;
 
+export const Section = styled.div`
+  display: flex;
+  flex-direction: column;
+  /* HACK: 32px에 해당하는 gap 토큰 없음(gap.8=24px이 최대). Figma 스펙(32px) 일치 위해 직접 사용. */
+  gap: 32px;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${getToken('gap.8')};
+`;
+
 export const TextSection = styled.div`
   display: flex;
   flex-direction: column;

--- a/src/shared/design-system/ui/Dialog/Dialog.tsx
+++ b/src/shared/design-system/ui/Dialog/Dialog.tsx
@@ -5,24 +5,37 @@ import * as S from './Dialog.styles';
 interface DialogAction {
   label: string;
   onClick: () => void;
+  disabled?: boolean;
 }
 
 interface DialogProps {
   title: ReactNode;
   description?: ReactNode;
+  children?: ReactNode;
   mainAction: DialogAction;
   alternativeAction?: DialogAction;
 }
 
 function Dialog(props: DialogProps) {
-  const { title, description, mainAction, alternativeAction } = props;
+  const { title, description, children, mainAction, alternativeAction } = props;
+
+  const textSection = (
+    <S.TextSection>
+      <S.Title>{title}</S.Title>
+      {description && <S.Description>{description}</S.Description>}
+    </S.TextSection>
+  );
 
   return (
     <S.Container>
-      <S.TextSection>
-        <S.Title>{title}</S.Title>
-        {description && <S.Description>{description}</S.Description>}
-      </S.TextSection>
+      {children ? (
+        <S.Section>
+          {textSection}
+          <S.Content>{children}</S.Content>
+        </S.Section>
+      ) : (
+        textSection
+      )}
       <ActionArea
         layout="horizontal"
         mainAction={mainAction}


### PR DESCRIPTION
## Summary
- 정산 상세 관리 메뉴의 "계좌 수정"을 활성화하고 계좌 수정 다이얼로그(`AccountEditDialog`)를 연결
- 은행 선택을 위한 신규 `Dropdown` 컴포넌트 추가 (바텀시트/기존 Select 미사용)
- 공용 `Dialog`에 children 슬롯과 action `disabled` 지원 추가
- 계좌 수정 성공 시 header 조회(`['groupHeader', groupToken]`) invalidate로 갱신

## 변경 사항
- `Dialog`: children 슬롯, mainAction `disabled` 지원
- `Dropdown`: bordered 트리거 + 패널, 외부 클릭/ESC 닫기, 선택 체크 표시
- `AccountEditDialog`: 은행 선택(Dropdown) + 계좌 번호(Input)로 구성된 controlled 다이얼로그
- `ManageMenu`: 계좌 수정 버튼 활성화, mutate 연결, 권한 없음(403) 에러 처리, 성공 시 header 갱신

## Test plan
- [ ] 관리 메뉴에서 "계좌 수정" 클릭 시 다이얼로그 오픈
- [ ] 은행 선택 드롭다운 동작 (외부 클릭/ESC 닫힘, 선택 체크)
- [ ] 은행/계좌번호 미입력 시 확인 버튼 disabled
- [ ] 수정 성공 시 토스트 노출 + header 갱신
- [ ] 총무가 아닌 경우 권한 없음 에러 바운더리 노출