### PR TITLE
빈 정산 카드UI 추가 및 홈 노출

### DIFF
--- a/src/pages/home/ui/EmptySettlementCard/EmptySettlementCard.styles.ts
+++ b/src/pages/home/ui/EmptySettlementCard/EmptySettlementCard.styles.ts
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+import { Link } from 'react-router';
+import SvgSystemWarning from '@/shared/assets/svgs/icon/SystemWarning';
+import { getToken, applyTypography } from '@/shared/design-system';
+
+export const Container = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  /* HACK: Figma gap 14px, 가장 가까운 gap.5(12px) 사용 */
+  gap: ${getToken('gap.5')};
+  width: 100%;
+  background: ${getToken('fill.neutral')};
+  border-radius: ${getToken('radius.xl')};
+  /* HACK: Figma py 18px, 가장 가까운 padding.6(20px) 사용 */
+  padding: ${getToken('padding.6')};
+  text-decoration: none;
+  color: inherit;
+`;
+
+export const TextGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const GroupName = styled.span`
+  ${applyTypography('typography.body.medium')}
+  color: ${getToken('fg.alternative')};
+`;
+
+export const Amount = styled.span`
+  ${applyTypography('typography.heading.small')}
+  color: ${getToken('fg.normal')};
+`;
+
+export const ProgressSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${getToken('gap.4')};
+`;
+
+export const ProgressBar = styled.div`
+  position: relative;
+  width: 100%;
+  height: 0.5rem;
+  overflow: hidden;
+`;
+
+export const ProgressTrack = styled.div`
+  position: absolute;
+  inset: 0;
+  border-radius: ${getToken('radius.full')};
+  /* 대응되는 시맨틱 토큰이 없어 Figma 지정값 사용 */
+  background: #d6d6d6;
+`;
+
+export const MessageRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: ${getToken('gap.2')};
+`;
+
+export const WarningIcon = styled(SvgSystemWarning)`
+  color: ${getToken('fg.accent-yellow.normal')};
+`;
+
+export const Message = styled.span`
+  ${applyTypography('typography.body.small-semibold')}
+  color: ${getToken('fg.assistive')};
+`;

--- a/src/pages/home/ui/EmptySettlementCard/EmptySettlementCard.tsx
+++ b/src/pages/home/ui/EmptySettlementCard/EmptySettlementCard.tsx
@@ -1,0 +1,38 @@
+import * as S from './EmptySettlementCard.styles';
+
+interface EmptySettlementCardProps {
+  groupCode: string;
+  groupName: string;
+}
+
+function EmptySettlementCard({
+  groupCode,
+  groupName,
+}: EmptySettlementCardProps) {
+  return (
+    <S.Container to={`/create-expense/${groupCode}`}>
+      <S.TextGroup>
+        <S.GroupName>{groupName}</S.GroupName>
+        <S.Amount>0원</S.Amount>
+      </S.TextGroup>
+      <S.ProgressSection>
+        <S.ProgressBar
+          role="progressbar"
+          aria-label={`${groupName} 정산 진행률`}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={0}
+        >
+          <S.ProgressTrack />
+        </S.ProgressBar>
+        <S.MessageRow>
+          <S.WarningIcon width={24} height={24} />
+          <S.Message>아직 정산 내역을 입력하지 않았어요</S.Message>
+        </S.MessageRow>
+      </S.ProgressSection>
+    </S.Container>
+  );
+}
+
+export { EmptySettlementCard };
+export type { EmptySettlementCardProps };

--- a/src/pages/home/ui/EmptySettlementCard/index.ts
+++ b/src/pages/home/ui/EmptySettlementCard/index.ts
@@ -1,0 +1,2 @@
+export { EmptySettlementCard } from './EmptySettlementCard';
+export type { EmptySettlementCardProps } from './EmptySettlementCard';

--- a/src/pages/home/ui/SettlementDateSection/SettlementDateSection.tsx
+++ b/src/pages/home/ui/SettlementDateSection/SettlementDateSection.tsx
@@ -1,4 +1,5 @@
 import type { SettlementGroup } from '@/entities/group/model/group.type';
+import { EmptySettlementCard } from '../EmptySettlementCard';
 import { SettlementProgressCard } from '../SettlementProgressCard';
 import * as S from './SettlementDateSection.styles';
 
@@ -12,16 +13,24 @@ function SettlementDateSection({ date, items }: SettlementDateSectionProps) {
     <S.Section>
       <S.Date>{date}</S.Date>
       <S.CardList>
-        {items.map((item) => (
-          <SettlementProgressCard
-            key={item.groupId}
-            groupCode={item.groupCode}
-            groupName={item.name}
-            totalAmount={item.totalAmount}
-            paidMember={item.completedMemberCount}
-            totalMember={item.totalMemberCount}
-          />
-        ))}
+        {items.map((item) =>
+          item.totalAmount === 0 ? (
+            <EmptySettlementCard
+              key={item.groupId}
+              groupCode={item.groupCode}
+              groupName={item.name}
+            />
+          ) : (
+            <SettlementProgressCard
+              key={item.groupId}
+              groupCode={item.groupCode}
+              groupName={item.name}
+              totalAmount={item.totalAmount}
+              paidMember={item.completedMemberCount}
+              totalMember={item.totalMemberCount}
+            />
+          )
+        )}
       </S.CardList>
     </S.Section>
   );


### PR DESCRIPTION
## Summary
- 지출이 없는 빈 정산(`totalAmount === 0`)을 표시하는 `EmptySettlementCard` 컴포넌트 추가
- 홈 정산 리스트(`SettlementDateSection`)에서 빈 정산은 `EmptySettlementCard`, 그 외에는 기존 `SettlementProgressCard`로 분기 렌더링
- 카드 클릭 시 지출 생성 페이지(`/create-expense/{groupCode}`)로 이동

## Details
- Figma 디자인 기반 구현, 기존 `SettlementProgressCard`와 동일한 토큰/레이아웃 컨벤션 사용
- 경고 아이콘은 `SystemWarning`(노란 삼각형, `fg.accent-yellow.normal`) + "아직 정산 내역을 입력하지 않았어요" 메시지
- 진행바 트랙은 대응 시맨틱 토큰이 없어 Figma 지정값 `#d6d6d6` 사용(주석 명시)

## Test plan
- [ ] 홈에서 `totalAmount === 0`인 정산이 빈 정산 카드로 노출되는지 확인
- [ ] 빈 정산 카드 클릭 시 `/create-expense/{groupCode}`로 이동하는지 확인
- [ ] 지출이 있는 정산은 기존 진행 카드로 정상 노출되는지 확인
- [ ] Figma 디자인과 시각적으로 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 정산 항목이 없을 때를 위한 새로운 빈 상태 카드 UI가 추가되었습니다. 카드에는 그룹 이름, 0원 금액 표시, 진행률 표시기, 정산 항목이 없다는 것을 알려주는 경고 메시지가 포함됩니다. 사용자는 이 카드를 통해 새로운 정산을 바로 시작할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->